### PR TITLE
Approach 1: More fine-grained LALR parser for markdowns

### DIFF
--- a/src/helper.py
+++ b/src/helper.py
@@ -1,8 +1,8 @@
 import os
 from os import path
 
-metadata_defaults = {'Instantiability': 'Concrete', 'Status': 'Stable'}
-property_defaults = {'minCount': 0, 'maxCount': '*'}
+metadata_defaults = {'Instantiability': ['Concrete'], 'Status': ['Stable']}
+property_defaults = {'minCount': ['0'], 'maxCount': ['*']}
 
 
 def safe_open(fname, *args):

--- a/src/utils.py
+++ b/src/utils.py
@@ -94,59 +94,36 @@ class SpecClass:
 
     def extract_metadata(self, mdata_list):
 
-        for ulista in mdata_list:
-
-            # strip the md list identifier, ie r'[-*+]'
-            ulista = re.split(r'[-*+]', ulista, 1)[-1].strip()
-
-            # strip the key and value in metadata entry, ie. <key>: <value>
-            ulista = re.split(r':', ulista, 1)
-
-            if len(ulista) != 1:
-                # report the invalid syntax
-                pass
-
-            _key = ulista[0].strip()
-            _value = ulista[-1].strip()
+        for _dict in mdata_list:
+            
+            _key = _dict['name']
+            _values = _dict['values']
 
             if _key in self.metadata:
                 # report the error
                 pass
             
-            self.metadata[_key] = _value
+            self.metadata[_key] = _values
 
     def extract_properties(self, props_list):
 
         for prop in props_list:
 
             name = prop['name']
-            subprops = prop['subprops']
-
-            # strip the md list identifier from name, ie r'[-*+]'
-            name = re.split(r'[-*+]', name, 1)[-1].strip()
+            avline_list = prop['values']
 
             subprops_dict = dict()
 
-            for ulistb in subprops:
+            for avline in avline_list:
 
-                # strip the md list identifier, ie r'[-*+]'
-                ulistb = re.split(r'[-*+]', ulistb, 1)[-1]
-
-                # strip the key and value in metadata entry, ie. <key>: <value>
-                ulistb = re.split(r':', ulistb, 1)
-
-                if len(ulistb) != 1:
-                    # report the invalid syntax
-                    pass
-
-                _key = ulistb[0].strip()
-                _value = ulistb[-1].strip()
+                _key = avline['name']
+                _values = avline['values']
 
                 if _key in subprops_dict:
                     # report the error
                     pass
 
-                subprops_dict[_key] = _value
+                subprops_dict[_key] = _values
 
             if name in self.properties:
                 # report the error
@@ -179,8 +156,8 @@ class SpecClass:
 
             # write the metadata
             f.write(f'## Metadata\n\n')
-            for name, val in self.metadata.items():
-                f.write(f'- {name}: {val}\n')
+            for name, vals in self.metadata.items():
+                f.write(f'- {name}: {" ".join(vals)}\n')
             f.write('\n')
 
             # write the data_props
@@ -188,7 +165,7 @@ class SpecClass:
             for name, subprops in self.properties.items():
                 f.write(f'- {name}\n')
                 for _key, subprop in subprops.items():
-                    f.write(f'  - {_key}: {subprop}\n')
+                    f.write(f'  - {_key}: {" ".join(subprop)}\n')
                 f.write('\n')
 
 
@@ -209,26 +186,16 @@ class SpecProperty:
 
     def extract_metadata(self, mdata_list):
 
-        for ulista in mdata_list:
+        for mdata_line in mdata_list:
 
-            # strip the md list identifier, ie r'[-*+]'
-            ulista = re.split(r'[-*+]', ulista, 1)[-1]
-
-            # strip the key and value in metadata entry, ie. <key>: <value>
-            ulista = re.split(r':', ulista, 1)
-
-            if len(ulista) != 1:
-                # report the invalid syntax
-                pass
-
-            _key = ulista[0].strip()
-            _value = ulista[-1].strip()
+            _key = mdata_line['name']
+            _values = mdata_line['values']
 
             if _key in self.metadata:
                 # report the error
                 pass
 
-            self.metadata[_key] = _value
+            self.metadata[_key] = _values
 
     def dump_md(self, fname):
 
@@ -256,7 +223,7 @@ class SpecProperty:
             # write the metadata
             f.write(f'## Metadata\n\n')
             for name, val in self.metadata.items():
-                f.write(f'- {name}: {val}\n')
+                f.write(f'- {name}: {" ".join(val)}\n')
 
 
 class SpecVocab:
@@ -279,49 +246,29 @@ class SpecVocab:
 
     def extract_metadata(self, mdata_list):
 
-        for ulista in mdata_list:
+        for mdata_line in mdata_list:
 
-            # strip the md list identifier, ie r'[-*+]'
-            ulista = re.split(r'[-*+]', ulista, 1)[-1]
-
-            # strip the key and value in metadata entry, ie. <key>: <value>
-            ulista = re.split(r':', ulista, 1)
-
-            if len(ulista) != 1:
-                # report the invalid syntax
-                pass
-
-            _key = ulista[0].strip()
-            _value = ulista[-1].strip()
+            _key = mdata_line['name']
+            _values = mdata_line['values']
 
             if _key in self.metadata:
                 # report the error
                 pass
 
-            self.metadata[_key] = _value
+            self.metadata[_key] = _values
 
-    def extract_entries(self, entries_list):
+    def extract_entries(self, entry_list):
 
-        for ulista in entries_list:
+        for entry in entry_list:
 
-            # strip the md list identifier, ie r'[-*+]'
-            ulista = re.split(r'[-*+]', ulista, 1)[-1]
-
-            # strip the key and value in metadata entry, ie. <key>: <value>
-            ulista = re.split(r':', ulista, 1)
-
-            if len(ulista) != 1:
-                # report the invalid syntax
-                pass
-
-            _key = ulista[0].strip()
-            _value = ulista[-1].strip()
+            _key = entry['name']
+            _values = entry['values']
 
             if _key in self.entries:
                 # report the error
                 pass
 
-            self.entries[_key] = _value
+            self.entries[_key] = _values
 
     def dump_md(self, fname):
 
@@ -349,10 +296,10 @@ class SpecVocab:
             # write the metadata
             f.write(f'## Metadata\n\n')
             for name, val in self.metadata.items():
-                f.write(f'- {name}: {val}\n')
+                f.write(f'- {name}: {" ".join(val)}\n')
             f.write('\n')
 
             # write the entries
             f.write(f'## Entries\n\n')
             for name, val in self.entries.items():
-                f.write(f'- {name}: {val}\n')
+                f.write(f'- {name}: {" ".join(val)}\n')


### PR DESCRIPTION
Initial attempt to solve #17, #15

This approach uses Lexer state to support tokenizing with different context.

- simple textline ( for summary and description text)
- specialized word tokens (for attribute key and attribute values)

Possible issue with this approach:
The lexer cannot differentiate between metadata's `attrib:values` and Vocab-Entries `attrib:description`. 
So `description` in `attrib:description` will have same restrictions as `values` in `attrib:values`  