### PR TITLE
Approach 2: More fine-grained LALR parser for markdowns

### DIFF
--- a/src/helper.py
+++ b/src/helper.py
@@ -1,8 +1,8 @@
 import os
 from os import path
 
-metadata_defaults = {'Instantiability': 'Concrete', 'Status': 'Stable'}
-property_defaults = {'minCount': 0, 'maxCount': '*'}
+metadata_defaults = {'Instantiability': ['Concrete'], 'Status': ['Stable']}
+property_defaults = {'minCount': ['0'], 'maxCount': ['*']}
 
 
 def safe_open(fname, *args):

--- a/src/parser.py
+++ b/src/parser.py
@@ -21,7 +21,6 @@ class MyLogger(object):
 
     critical = debug
 
-
 class MDLexer(Lexer):
 
     tokens = {
@@ -34,7 +33,7 @@ class MDLexer(Lexer):
         DESCRIPTION,
         SUMMARY,
         METADATA,
-        DATAPROP,
+        PROPERTIES,
         ENTRIES,
         TEXTLINE,
         ULISTA,
@@ -45,7 +44,7 @@ class MDLexer(Lexer):
     SUMMARY = r'((?<=\n)|^)\#{2}\s+Summary\s+(\n+|$)'
     DESCRIPTION = r'((?<=\n)|^)\#{2}\s+Description\s+(\n+|$)'
     METADATA = r'((?<=\n)|^)\#{2}\s+Metadata\s+(\n+|$)'
-    DATAPROP = r'((?<=\n)|^)\#{2}\s+Properties\s+(\n+|$)'
+    PROPERTIES = r'((?<=\n)|^)\#{2}\s+Properties\s+(\n+|$)'
     ENTRIES = r'((?<=\n)|^)\#{2}\s+Entries\s+(\n+|$)'
 
     H6 = r'((?<=\n)|^)\#{6}'
@@ -71,15 +70,17 @@ class MDLexer(Lexer):
         print("Illegal character '%s'" % t.value[0])
         self.index += 1
 
-
 class MDClass(Parser):
 
     # debugfile = 'parser.out'
     log = MyLogger(sys.stderr)
     tokens = MDLexer.tokens
+    isError = False
 
-    @_('newlines name summary description metadata properties')
+    @_('maybe_newlines name summary description metadata properties')
     def document(self, p):
+        if self.isError:
+            return None
         return SpecClass(p.name, p.summary, p.description, p.metadata, p.properties)
 
     @_('H1 TEXTLINE')
@@ -107,37 +108,87 @@ class MDClass(Parser):
             return []
         return p.metadata_list
 
-    @_('metadata_list ULISTA',
+    @_('metadata_list metadata_line',
         'empty')
     def metadata_list(self, p):
         if len(p) == 2:
-            return p.metadata_list+[p.ULISTA.strip()]
+            return p.metadata_list+[p.metadata_line]
         return []
 
-    @_('DATAPROP entries',
+    @_('ULISTA')
+    def metadata_line(self, p):
+        
+        ulista = p.ULISTA
+
+        # strip the md list identifier, ie r'[-*+]'
+        ulista = re.split(r'[-*+]', ulista, 1)[-1].strip()
+
+        # strip the key and value in metadata entry, ie. <key>: <value>
+        ulista = re.split(r'\s*:\s', ulista, 1)
+
+        if len(ulista) != 2:
+            # report the invalid syntax
+            self.error(p._slice[0])
+            return None
+
+        _key = ulista[0].strip()
+        _values = re.split(r'\s',ulista[-1].strip())
+
+        return {'name': _key, 'values': _values}
+
+    @_('PROPERTIES properties_list',
         'empty')
     def properties(self, p):
         if len(p) == 1:
             return []
-        return p.entries
+        return p.properties_list
 
-    @_('entries entry',
+    @_('properties_list single_property',
         'empty')
-    def entries(self, p):
+    def properties_list(self, p):
         if len(p) == 1:
             return []
-        return p.entries+[p.entry]
+        return p.properties_list+[p.single_property]
 
-    @_('ULISTA entry_sublist')
-    def entry(self, p):
-        return {'name': p.ULISTA.strip(), 'subprops': p.entry_sublist}
+    @_('ULISTA avline_list')
+    def single_property(self, p):
+        
+        ulista = p.ULISTA
 
-    @_('entry_sublist ULISTB',
-        'empty')
-    def entry_sublist(self, p):
+        # strip the md list identifier, ie r'[-*+]'
+        ulista = re.split(r'[-*+]', ulista, 1)[-1].strip()
+
+        return {'name': ulista, 'values': p.avline_list}
+
+    @_('avline_list avline',
+        'avline')
+    def avline_list(self, p):
         if len(p) == 1:
-            return []
-        return p.entry_sublist + [p.ULISTB.strip()]
+            return [p.avline]
+        return p.avline_list + [p.avline]
+
+    @_('ULISTB')
+    def avline(self, p):
+        
+        ulistb = p.ULISTB
+
+        # strip the md list identifier, ie r'[-*+]'
+        ulistb = re.split(r'[-*+]', ulistb, 1)[-1].strip()
+
+        # strip the key and value in metadata entry, ie. <key>: <values>
+        ulistb = re.split(r'\s*:\s', ulistb, 1)
+
+        if len(ulistb) != 2:
+            # report the invalid syntax
+            self.error(p._slice[0])
+            return None
+
+        _key = ulistb[0].strip()
+
+        # split values by whitespaces
+        _values = re.split(r'\s',ulistb[-1].strip())
+
+        return {'name': _key, 'values': _values}
 
     @_('para TEXTLINE',
         'empty')
@@ -145,11 +196,15 @@ class MDClass(Parser):
         if len(p) == 1:
             return ''
         else:
-            return f"{p.para} {p.TEXTLINE}".strip()
+            return f"{p.para} {p.TEXTLINE.strip()}"
 
-    @_('NEWLINE',
-        'empty')
+    @_('NEWLINE')
     def newlines(self, p):
+        return None
+
+    @_('newlines',
+        'empty')
+    def maybe_newlines(self, p):
         return None
 
     @_('')
@@ -157,21 +212,21 @@ class MDClass(Parser):
         return None
 
     def error(self, p):
+        self.isError = True
         print('ERROR: ', p)
         return None
-
 
 class MDProperty(Parser):
 
     # debugfile = 'parser.out'
     log = MyLogger(sys.stderr)
     tokens = MDLexer.tokens
+    isError = False
 
-    # debugfile = 'parser.out'
-    tokens = MDLexer.tokens
-
-    @_('newlines name summary description metadata')
+    @_('maybe_newlines name summary description metadata')
     def document(self, p):
+        if self.isError:
+            return None
         return SpecProperty(p.name, p.summary, p.description, p.metadata)
 
     @_('H1 TEXTLINE')
@@ -199,12 +254,33 @@ class MDProperty(Parser):
             return []
         return p.metadata_list
 
-    @_('metadata_list ULISTA',
+    @_('metadata_list metadata_line',
         'empty')
     def metadata_list(self, p):
         if len(p) == 2:
-            return p.metadata_list+[p.ULISTA.strip()]
+            return p.metadata_list+[p.metadata_line]
         return []
+
+    @_('ULISTA')
+    def metadata_line(self, p):
+        
+        ulista = p.ULISTA
+
+        # strip the md list identifier, ie r'[-*+]'
+        ulista = re.split(r'[-*+]', ulista, 1)[-1].strip()
+
+        # strip the key and value in metadata entry, ie. <key>: <value>
+        ulista = re.split(r'\s*:\s', ulista, 1)
+
+        if len(ulista) != 2:
+            # report the invalid syntax
+            self.error(p._slice[0])
+            return None
+
+        _key = ulista[0].strip()
+        _values = re.split(r'\s',ulista[-1].strip())
+
+        return {'name': _key, 'values': _values}
 
     @_('para TEXTLINE',
         'empty')
@@ -214,9 +290,13 @@ class MDProperty(Parser):
         else:
             return f"{p.para} {p.TEXTLINE.strip()}"
 
-    @_('NEWLINE',
-        'empty')
+    @_('NEWLINE')
     def newlines(self, p):
+        return None
+
+    @_('newlines',
+        'empty')
+    def maybe_newlines(self, p):
         return None
 
     @_('')
@@ -224,18 +304,21 @@ class MDProperty(Parser):
         return None
 
     def error(self, p):
+        self.isError = True
         print('ERROR: ', p)
         return None
 
 
-class MDVocab(Parser):
-
+class MDVocab(MDProperty):
     # debugfile = 'parser.out'
     log = MyLogger(sys.stderr)
     tokens = MDLexer.tokens
+    isError = False
 
-    @_('newlines name summary description metadata entries')
+    @_('maybe_newlines name summary description metadata entries')
     def document(self, p):
+        if self.isError:
+            return None
         return SpecVocab(p.name, p.summary, p.description, p.metadata, p.entries)
 
     @_('H1 TEXTLINE')
@@ -263,26 +346,68 @@ class MDVocab(Parser):
             return []
         return p.metadata_list
 
-    @_('metadata_list ULISTA',
+    @_('metadata_list metadata_line',
         'empty')
     def metadata_list(self, p):
         if len(p) == 2:
-            return p.metadata_list+[p.ULISTA.strip()]
+            return p.metadata_list+[p.metadata_line]
         return []
 
-    @_('ENTRIES entries_list',
+    @_('ULISTA')
+    def metadata_line(self, p):
+        
+        ulista = p.ULISTA
+
+        # strip the md list identifier, ie r'[-*+]'
+        ulista = re.split(r'[-*+]', ulista, 1)[-1].strip()
+
+        # strip the key and value in metadata entry, ie. <key>: <value>
+        ulista = re.split(r'\s*:\s', ulista, 1)
+
+        if len(ulista) != 2:
+            # report the invalid syntax
+            self.error(p._slice[0])
+            return None
+
+        _key = ulista[0].strip()
+        _values = re.split(r'\s',ulista[-1].strip())
+
+        return {'name': _key, 'values': _values}
+
+    @_('ENTRIES entry_list',
        'empty')
     def entries(self, p):
         if len(p) == 1:
             return []
-        return p.entries_list
+        return p.entry_list
 
-    @_('entries_list ULISTA',
+    @_('entry_list entry_line',
         'empty')
-    def entries_list(self, p):
+    def entry_list(self, p):
         if len(p) == 2:
-            return p.entries_list+[p.ULISTA.strip()]
+            return p.entry_list+[p.entry_line]
         return []
+
+    @_('ULISTA')
+    def entry_line(self, p):
+        
+        ulista = p.ULISTA
+
+        # strip the md list identifier, ie r'[-*+]'
+        ulista = re.split(r'[-*+]', ulista, 1)[-1].strip()
+
+        # strip the key and value in metadata entry, ie. <key>: <value>
+        ulista = re.split(r'\s*:\s', ulista, 1)
+
+        if len(ulista) != 2:
+            # report the invalid syntax
+            self.error(p._slice[0])
+            return None
+
+        _key = ulista[0].strip()
+        _value = ulista[-1].strip()
+
+        return {'name': _key, 'value': _value}
 
     @_('para TEXTLINE',
         'empty')
@@ -292,9 +417,13 @@ class MDVocab(Parser):
         else:
             return f"{p.para} {p.TEXTLINE.strip()}"
 
-    @_('NEWLINE',
-        'empty')
+    @_('NEWLINE')
     def newlines(self, p):
+        return None
+
+    @_('newlines',
+        'empty')
+    def maybe_newlines(self, p):
         return None
 
     @_('')
@@ -302,16 +431,21 @@ class MDVocab(Parser):
         return None
 
     def error(self, p):
+        self.isError = True
         print('ERROR: ', p)
         return None
+
 
 
 if __name__ == '__main__':
 
     lexer = MDLexer()
-    parser = MDClass()
+    parser = MDVocab()
 
-    with open(sys.argv[1], "r") as f:
+    # fpath = sys.argv[1]
+    fpath = "spec-v3-template/model/Core/Vocabularies/HashAlgorithmVocab.md"
+
+    with open(fpath, "r") as f:
         inp = f.read()
 
     for tok in lexer.tokenize(inp):

--- a/src/parser.py
+++ b/src/parser.py
@@ -90,25 +90,16 @@ class MDClass(Parser):
     def name(self, p):
         return p.H_TEXTLINE.strip()
 
-    @_('SUMMARY para',
-        'empty')
+    @_('SUMMARY para')
     def summary(self, p):
-        if len(p) == 1:
-            return None
         return p.para.strip()
 
-    @_('DESCRIPTION para',
-        'empty')
+    @_('DESCRIPTION para')
     def description(self, p):
-        if len(p) == 1:
-            return None
         return p.para.strip()
 
-    @_('METADATA metadata_list',
-        'empty')
+    @_('METADATA metadata_list')
     def metadata(self, p):
-        if len(p) == 1:
-            return []
         return p.metadata_list
 
     @_('metadata_list metadata_line',
@@ -139,11 +130,8 @@ class MDClass(Parser):
 
         return {'name': _key, 'values': _values}
 
-    @_('PROPERTIES properties_list',
-        'empty')
+    @_('PROPERTIES properties_list')
     def properties(self, p):
-        if len(p) == 1:
-            return []
         return p.properties_list
 
     @_('properties_list single_property',
@@ -242,25 +230,16 @@ class MDProperty(Parser):
     def name(self, p):
         return p.H_TEXTLINE.strip()
 
-    @_('SUMMARY para',
-        'empty')
+    @_('SUMMARY para')
     def summary(self, p):
-        if len(p) == 1:
-            return None
         return p.para.strip()
 
-    @_('DESCRIPTION para',
-        'empty')
+    @_('DESCRIPTION para')
     def description(self, p):
-        if len(p) == 1:
-            return None
         return p.para.strip()
 
-    @_('METADATA metadata_list',
-        'empty')
+    @_('METADATA metadata_list')
     def metadata(self, p):
-        if len(p) == 1:
-            return []
         return p.metadata_list
 
     @_('metadata_list metadata_line',
@@ -340,25 +319,16 @@ class MDVocab(MDProperty):
     def name(self, p):
         return p.H_TEXTLINE.strip()
 
-    @_('SUMMARY para',
-        'empty')
+    @_('SUMMARY para')
     def summary(self, p):
-        if len(p) == 1:
-            return None
         return p.para.strip()
 
-    @_('DESCRIPTION para',
-        'empty')
+    @_('DESCRIPTION para')
     def description(self, p):
-        if len(p) == 1:
-            return None
         return p.para.strip()
 
-    @_('METADATA metadata_list',
-        'empty')
+    @_('METADATA metadata_list')
     def metadata(self, p):
-        if len(p) == 1:
-            return []
         return p.metadata_list
 
     @_('metadata_list metadata_line',
@@ -389,11 +359,8 @@ class MDVocab(MDProperty):
 
         return {'name': _key, 'values': _values}
 
-    @_('ENTRIES entry_list',
-       'empty')
+    @_('ENTRIES entry_list')
     def entries(self, p):
-        if len(p) == 1:
-            return []
         return p.entry_list
 
     @_('entry_list entry_line',

--- a/src/utils.py
+++ b/src/utils.py
@@ -94,59 +94,36 @@ class SpecClass:
 
     def extract_metadata(self, mdata_list):
 
-        for ulista in mdata_list:
-
-            # strip the md list identifier, ie r'[-*+]'
-            ulista = re.split(r'[-*+]', ulista, 1)[-1].strip()
-
-            # strip the key and value in metadata entry, ie. <key>: <value>
-            ulista = re.split(r':', ulista, 1)
-
-            if len(ulista) != 1:
-                # report the invalid syntax
-                pass
-
-            _key = ulista[0].strip()
-            _value = ulista[-1].strip()
+        for _dict in mdata_list:
+            
+            _key = _dict['name']
+            _values = _dict['values']
 
             if _key in self.metadata:
                 # report the error
                 pass
             
-            self.metadata[_key] = _value
+            self.metadata[_key] = _values
 
     def extract_properties(self, props_list):
 
         for prop in props_list:
 
             name = prop['name']
-            subprops = prop['subprops']
-
-            # strip the md list identifier from name, ie r'[-*+]'
-            name = re.split(r'[-*+]', name, 1)[-1].strip()
+            avline_list = prop['values']
 
             subprops_dict = dict()
 
-            for ulistb in subprops:
+            for avline in avline_list:
 
-                # strip the md list identifier, ie r'[-*+]'
-                ulistb = re.split(r'[-*+]', ulistb, 1)[-1]
-
-                # strip the key and value in metadata entry, ie. <key>: <value>
-                ulistb = re.split(r':', ulistb, 1)
-
-                if len(ulistb) != 1:
-                    # report the invalid syntax
-                    pass
-
-                _key = ulistb[0].strip()
-                _value = ulistb[-1].strip()
+                _key = avline['name']
+                _values = avline['values']
 
                 if _key in subprops_dict:
                     # report the error
                     pass
 
-                subprops_dict[_key] = _value
+                subprops_dict[_key] = _values
 
             if name in self.properties:
                 # report the error
@@ -179,8 +156,8 @@ class SpecClass:
 
             # write the metadata
             f.write(f'## Metadata\n\n')
-            for name, val in self.metadata.items():
-                f.write(f'- {name}: {val}\n')
+            for name, vals in self.metadata.items():
+                f.write(f'- {name}: {" ".join(vals)}\n')
             f.write('\n')
 
             # write the data_props
@@ -188,7 +165,7 @@ class SpecClass:
             for name, subprops in self.properties.items():
                 f.write(f'- {name}\n')
                 for _key, subprop in subprops.items():
-                    f.write(f'  - {_key}: {subprop}\n')
+                    f.write(f'  - {_key}: {" ".join(subprop)}\n')
                 f.write('\n')
 
 
@@ -209,26 +186,16 @@ class SpecProperty:
 
     def extract_metadata(self, mdata_list):
 
-        for ulista in mdata_list:
+        for mdata_line in mdata_list:
 
-            # strip the md list identifier, ie r'[-*+]'
-            ulista = re.split(r'[-*+]', ulista, 1)[-1]
-
-            # strip the key and value in metadata entry, ie. <key>: <value>
-            ulista = re.split(r':', ulista, 1)
-
-            if len(ulista) != 1:
-                # report the invalid syntax
-                pass
-
-            _key = ulista[0].strip()
-            _value = ulista[-1].strip()
+            _key = mdata_line['name']
+            _values = mdata_line['values']
 
             if _key in self.metadata:
                 # report the error
                 pass
 
-            self.metadata[_key] = _value
+            self.metadata[_key] = _values
 
     def dump_md(self, fname):
 
@@ -256,7 +223,7 @@ class SpecProperty:
             # write the metadata
             f.write(f'## Metadata\n\n')
             for name, val in self.metadata.items():
-                f.write(f'- {name}: {val}\n')
+                f.write(f'- {name}: {" ".join(val)}\n')
 
 
 class SpecVocab:
@@ -279,43 +246,23 @@ class SpecVocab:
 
     def extract_metadata(self, mdata_list):
 
-        for ulista in mdata_list:
+        for mdata_line in mdata_list:
 
-            # strip the md list identifier, ie r'[-*+]'
-            ulista = re.split(r'[-*+]', ulista, 1)[-1]
-
-            # strip the key and value in metadata entry, ie. <key>: <value>
-            ulista = re.split(r':', ulista, 1)
-
-            if len(ulista) != 1:
-                # report the invalid syntax
-                pass
-
-            _key = ulista[0].strip()
-            _value = ulista[-1].strip()
+            _key = mdata_line['name']
+            _values = mdata_line['values']
 
             if _key in self.metadata:
                 # report the error
                 pass
 
-            self.metadata[_key] = _value
+            self.metadata[_key] = _values
 
-    def extract_entries(self, entries_list):
+    def extract_entries(self, entry_list):
 
-        for ulista in entries_list:
+        for entry in entry_list:
 
-            # strip the md list identifier, ie r'[-*+]'
-            ulista = re.split(r'[-*+]', ulista, 1)[-1]
-
-            # strip the key and value in metadata entry, ie. <key>: <value>
-            ulista = re.split(r':', ulista, 1)
-
-            if len(ulista) != 1:
-                # report the invalid syntax
-                pass
-
-            _key = ulista[0].strip()
-            _value = ulista[-1].strip()
+            _key = entry['name']
+            _value = entry['value']
 
             if _key in self.entries:
                 # report the error
@@ -349,7 +296,7 @@ class SpecVocab:
             # write the metadata
             f.write(f'## Metadata\n\n')
             for name, val in self.metadata.items():
-                f.write(f'- {name}: {val}\n')
+                f.write(f'- {name}: {" ".join(val)}\n')
             f.write('\n')
 
             # write the entries


### PR DESCRIPTION
Initial attempt to solve #17, #15

This approach uses parser actions to report fine-grained errors. In this approach, we do not change grammar, only parser actions.

The advantage of this approach compared to #18 is that, we can differentiate between metadata's `attrib:values` and Vocab-Entries `attrib:description`. 