### PR TITLE
Use logging module for centralizing logs

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,8 @@
+id_metadata_prefix = 'https://spdx.org/rdf/'
+
+valid_metadata_key = ['name', 'SubclassOf',
+                      'Nature', 'Range', 'Instantiability', 'Status']
+valid_dataprop_key = ['type', 'minCount', 'maxCount']
+
+metadata_defaults = {'Instantiability': ['Concrete'], 'Status': ['Stable']}
+property_defaults = {'minCount': ['0'], 'maxCount': ['*']}

--- a/src/driver.py
+++ b/src/driver.py
@@ -15,6 +15,9 @@ def get_args():
     argparser.add_argument('--md', action="store_true",
                            help='Dumps markdown')
 
+    argparser.add_argument('--refs', action="store_true",
+                           help='Generate References list for Property')
+
     argparser.add_argument('--out', type=str,
                            help='Output Directory for generating markdown')
 
@@ -45,4 +48,4 @@ if __name__ == '__main__':
     specParser = SpecParser()
     spec = specParser.parse(args.spec_dir)
     if args.md:
-        spec.dump_md(args.out)
+        spec.dump_md(args)

--- a/src/driver.py
+++ b/src/driver.py
@@ -1,7 +1,7 @@
 import os
+import logging
 from argparse import ArgumentParser
-from spec_parser import SpecParser
-
+from helper import ErrorFoundFilter, isError
 
 def get_args():
 
@@ -13,6 +13,7 @@ def get_args():
 
     argparser.add_argument('--md', action="store_true",
                            help='Dumps markdown')
+
 
     argparser.add_argument('--out', type=str,
                            help='Output Directory for generating markdown')
@@ -26,6 +27,12 @@ if __name__ == '__main__':
 
     args = get_args()
 
+    logging.basicConfig(format='%(name)-18s: %(levelname)-8s %(message)s')
+    logger = logging.getLogger()
+    for handler in logger.handlers:
+        handler.addFilter(ErrorFoundFilter())
+        break
+
     if not os.path.isdir(args.spec_dir):
         print(
             f'ERROR: Directory containing models :{args.spec_dir} doesn\'t exists')
@@ -34,8 +41,8 @@ if __name__ == '__main__':
     if args.out is None:
         args.out = 'md_generated'
 
+    from spec_parser import SpecParser
     specParser = SpecParser()
     spec = specParser.parse(args.spec_dir)
-
     if args.md:
         spec.dump_md(args.out)

--- a/src/driver.py
+++ b/src/driver.py
@@ -1,7 +1,8 @@
 import os
 import logging
 from argparse import ArgumentParser
-from helper import ErrorFoundFilter, isError
+from helper import ErrorFoundFilter
+
 
 def get_args():
 
@@ -13,7 +14,6 @@ def get_args():
 
     argparser.add_argument('--md', action="store_true",
                            help='Dumps markdown')
-
 
     argparser.add_argument('--out', type=str,
                            help='Output Directory for generating markdown')
@@ -34,8 +34,8 @@ if __name__ == '__main__':
         break
 
     if not os.path.isdir(args.spec_dir):
-        print(
-            f'ERROR: Directory containing models :{args.spec_dir} doesn\'t exists')
+        logger.error(
+            f'Error: Directory containing models :{args.spec_dir} doesn\'t exists')
         exit(1)
 
     if args.out is None:

--- a/src/helper.py
+++ b/src/helper.py
@@ -5,14 +5,17 @@ from os import path
 metadata_defaults = {'Instantiability': ['Concrete'], 'Status': ['Stable']}
 property_defaults = {'minCount': ['0'], 'maxCount': ['*']}
 
+
 class ErrorFoundFilter(logging.Filter):
     def __init__(self):
         self.worst_level = logging.INFO
+
     def filter(self, record):
         if record.levelno > self.worst_level:
             self.worst_level = record.levelno
         return True
-        
+
+
 def isError():
     logger = logging.getLogger()
     for handler in logger.handlers:
@@ -20,6 +23,7 @@ def isError():
             if isinstance(filter, ErrorFoundFilter):
                 return filter.worst_level >= logging.ERROR
     return False
+
 
 def safe_open(fname, *args):
     ''' Open "fname" after creating neccessary nested directories as needed.
@@ -35,10 +39,11 @@ def safe_listdir(dname):
         return os.listdir(dname)
     return []
 
+
 def union_dict(d1, d2):
     '''
     Concat two dict d1, d2. (inplace). Values in dict d1 will be given priority over dict d2.
     '''
-    for k,v in d2.items():
+    for k, v in d2.items():
         if not k in d1:
             d1[k] = v

--- a/src/helper.py
+++ b/src/helper.py
@@ -1,9 +1,25 @@
 import os
+import logging
 from os import path
 
 metadata_defaults = {'Instantiability': 'Concrete', 'Status': 'Stable'}
 property_defaults = {'minCount': 0, 'maxCount': '*'}
 
+class ErrorFoundFilter(logging.Filter):
+    def __init__(self):
+        self.worst_level = logging.INFO
+    def filter(self, record):
+        if record.levelno > self.worst_level:
+            self.worst_level = record.levelno
+        return True
+        
+def isError():
+    logger = logging.getLogger()
+    for handler in logger.handlers:
+        for filter in handler.filters:
+            if isinstance(filter, ErrorFoundFilter):
+                return filter.worst_level >= logging.ERROR
+    return False
 
 def safe_open(fname, *args):
     ''' Open "fname" after creating neccessary nested directories as needed.

--- a/src/helper.py
+++ b/src/helper.py
@@ -2,10 +2,6 @@ import os
 import logging
 from os import path
 
-metadata_defaults = {'Instantiability': ['Concrete'], 'Status': ['Stable']}
-property_defaults = {'minCount': ['0'], 'maxCount': ['*']}
-
-
 class ErrorFoundFilter(logging.Filter):
     def __init__(self):
         self.worst_level = logging.INFO

--- a/src/parser.py
+++ b/src/parser.py
@@ -4,6 +4,7 @@ import sys
 import sly
 from sly import Parser, Lexer
 from utils import SpecClass, SpecProperty, SpecVocab
+from config import valid_dataprop_key, valid_metadata_key
 
 
 def get_line(text: str, t: int):
@@ -95,7 +96,7 @@ class MDClass(Parser):
     def document(self, p):
         if getattr(self, 'isError', False):
             return None
-        return SpecClass(p.name, p.summary, p.description, p.metadata, p.properties)
+        return (p.name, p.summary, p.description, p.metadata, p.properties)
 
     @_('H1 H_TEXTLINE')
     def name(self, p):
@@ -138,6 +139,9 @@ class MDClass(Parser):
 
         _key = ulista[0].strip()
         _values = re.split(r'\s', ulista[-1].strip())
+
+        if _key not in valid_metadata_key:
+            self.error(p._slice[0], f"Error: Invalid metadata key `{_key}`.")
 
         if any(map(lambda x: x.get('name', '') == _key, p[-2])):
             self.error(
@@ -197,6 +201,10 @@ class MDClass(Parser):
         # split values by whitespaces
         _values = re.split(r'\s', ulistb[-1].strip())
 
+        if _key not in valid_dataprop_key:
+            self.error(
+                p._slice[0], f"Error: Invalid DataProperty Attribute key `{_key}`.")
+
         if any(map(lambda x: x.get('name', '') == _key, p[-2])):
             self.error(
                 p._slice[0], f"Error: Attribute key \'{_key}\' already exists")
@@ -247,7 +255,7 @@ class MDProperty(Parser):
     def document(self, p):
         if getattr(self, 'isError', False):
             return None
-        return SpecProperty(p.name, p.summary, p.description, p.metadata)
+        return (p.name, p.summary, p.description, p.metadata)
 
     @_('H1 H_TEXTLINE')
     def name(self, p):
@@ -290,6 +298,9 @@ class MDProperty(Parser):
 
         _key = ulista[0].strip()
         _values = re.split(r'\s', ulista[-1].strip())
+
+        if _key not in valid_metadata_key:
+            self.error(p._slice[0], f"Error: Invalid metadata key `{_key}`.")
 
         if any(map(lambda x: x.get('name', '') == _key, p[-2])):
             self.error(
@@ -340,7 +351,7 @@ class MDVocab(MDProperty):
     def document(self, p):
         if getattr(self, 'isError', False):
             return None
-        return SpecVocab(p.name, p.summary, p.description, p.metadata, p.entries)
+        return (p.name, p.summary, p.description, p.metadata, p.entries)
 
     @_('H1 H_TEXTLINE')
     def name(self, p):
@@ -383,6 +394,9 @@ class MDVocab(MDProperty):
 
         _key = ulista[0].strip()
         _values = re.split(r'\s', ulista[-1].strip())
+
+        if _key not in valid_metadata_key:
+            self.error(p._slice[0], f"Error: Invalid metadata key `{_key}`.")
 
         if any(map(lambda x: x.get('name', '') == _key, p[-2])):
             self.error(

--- a/src/parser.py
+++ b/src/parser.py
@@ -1,25 +1,25 @@
 from utils import *
+import logging
 import sys
 import re
 from sly import Parser, Lexer
 
+# class MyLogger(object):
+#     def __init__(self, f):
+#         self.f = f
 
-class MyLogger(object):
-    def __init__(self, f):
-        self.f = f
+#     def debug(self, msg, *args, **kwargs):
+#         self.f.write((msg % args) + '\n')
 
-    def debug(self, msg, *args, **kwargs):
-        self.f.write((msg % args) + '\n')
+#     info = debug
 
-    info = debug
+#     def warning(self, msg, *args, **kwargs):
+#         self.f.write('WARNING: ' + (msg % args) + '\n')
 
-    def warning(self, msg, *args, **kwargs):
-        self.f.write('WARNING: ' + (msg % args) + '\n')
+#     def error(self, msg, *args, **kwargs):
+#         self.f.write('ERROR: ' + (msg % args) + '\n')
 
-    def error(self, msg, *args, **kwargs):
-        self.f.write('ERROR: ' + (msg % args) + '\n')
-
-    critical = debug
+#     critical = debug
 
 
 class MDLexer(Lexer):
@@ -75,7 +75,7 @@ class MDLexer(Lexer):
 class MDClass(Parser):
 
     # debugfile = 'parser.out'
-    log = MyLogger(sys.stderr)
+    log = logging.getLogger(__name__+'.MDClass')
     tokens = MDLexer.tokens
 
     @_('newlines name summary description metadata properties')
@@ -164,7 +164,7 @@ class MDClass(Parser):
 class MDProperty(Parser):
 
     # debugfile = 'parser.out'
-    log = MyLogger(sys.stderr)
+    log = logging.getLogger(__name__+'.MDProperty')
     tokens = MDLexer.tokens
 
     # debugfile = 'parser.out'
@@ -231,7 +231,7 @@ class MDProperty(Parser):
 class MDVocab(Parser):
 
     # debugfile = 'parser.out'
-    log = MyLogger(sys.stderr)
+    log = logging.getLogger(f'{__name__}.MDVocab')
     tokens = MDLexer.tokens
 
     @_('newlines name summary description metadata entries')

--- a/src/parser.py
+++ b/src/parser.py
@@ -1,27 +1,39 @@
-from utils import *
 import logging
-import sys
 import re
+import sys
+import sly
 from sly import Parser, Lexer
+from utils import SpecClass, SpecProperty, SpecVocab
 
-# class MyLogger(object):
-#     def __init__(self, f):
-#         self.f = f
 
-#     def debug(self, msg, *args, **kwargs):
-#         self.f.write((msg % args) + '\n')
+def get_line(text: str, t: int):
+    lineno = text.count('\n', 0, t)+1
+    last_cr = text.rfind('\n', 0, t)
+    if last_cr < 0:
+        last_cr = 0
+    column = (t - last_cr) + 1
+    return lineno, column
 
-#     info = debug
 
-#     def warning(self, msg, *args, **kwargs):
-#         self.f.write('WARNING: ' + (msg % args) + '\n')
+def parser_error(self, p, msg=None):
+    self.isError = True
 
-#     def error(self, msg, *args, **kwargs):
-#         self.f.write('ERROR: ' + (msg % args) + '\n')
+    fname = getattr(self.lexer, 'fname', '<unknown>')
+    text = getattr(self.lexer, 'text', '')
+    index = getattr(p, 'index', 0)
 
-#     critical = debug
+    l, c = get_line(text, index)
+    if isinstance(p, sly.lex.Token):
+        self.log.error(
+            f'{fname}:Ln {l},Col {c}: {msg if msg is not None else "Syntax Error"}\n\t Line no {l}: {repr(p.value)}')
+    else:
+        self.log.error(f'{self.fname}:Ln {l},Col {c}: {p}')
+    return None
+
 
 class MDLexer(Lexer):
+
+    log = logging.getLogger('Parser.MDLexer')
 
     tokens = {
         H1,
@@ -43,13 +55,13 @@ class MDLexer(Lexer):
     }
 
     ignore_comment = r'<!?--(?:(?!-->)(.|\n|\s))*-->\n*'
-    
-    SUMMARY = r'((?<=\n)|^)\#{2}\s+Summary\s+(\n+|$)'
-    DESCRIPTION = r'((?<=\n)|^)\#{2}\s+Description\s+(\n+|$)'
-    METADATA = r'((?<=\n)|^)\#{2}\s+Metadata\s+(\n+|$)'
-    PROPERTIES = r'((?<=\n)|^)\#{2}\s+Properties\s+(\n+|$)'
-    ENTRIES = r'((?<=\n)|^)\#{2}\s+Entries\s+(\n+|$)'
-    
+
+    SUMMARY = r'((?<=\n)|^)\#{2}\s+Summary(?:(?!\n)\s)*(\n+|$)'
+    DESCRIPTION = r'((?<=\n)|^)\#{2}\s+Description(?:(?!\n)\s)*(\n+|$)'
+    METADATA = r'((?<=\n)|^)\#{2}\s+Metadata(?:(?!\n)\s)*(\n+|$)'
+    PROPERTIES = r'((?<=\n)|^)\#{2}\s+Properties(?:(?!\n)\s)*(\n+|$)'
+    ENTRIES = r'((?<=\n)|^)\#{2}\s+Entries(?:(?!\n)\s)*(\n+|$)'
+
     H6 = r'((?<=\n)|^)\s*\#{6}'
     H5 = r'((?<=\n)|^)\s*\#{5}'
     H4 = r'((?<=\n)|^)\s*\#{4}'
@@ -62,29 +74,28 @@ class MDLexer(Lexer):
     ULISTB = r'((?<=\n)|^)([ ]{2,4}|\t)[*+-][^\n]+(\n+|$)'
 
     TEXTLINE = r'((?<=\n)|^)[^\n]+(\n+|$)'
-
-    @_(r'\n+')
-    def NEWLINE(self, t):
-        self.lineno += len(t.value)
-        return t
+    NEWLINE = r'\n+'
 
     def error(self, t):
-        print("Illegal character '%s'" % t.value[0])
+        l, c = get_line(self.text, t)
+        fname = getattr(self, 'fname', '<unknown>')
+        self.log.error(
+            f'{fname}:Ln {l},Col {c}: Lexer Error: Illegal character {t.value[0]}')
         self.index += 1
+
 
 class MDClass(Parser):
 
     # debugfile = 'parser.out'
-    log = logging.getLogger(__name__+'.MDClass')
+    log = logging.getLogger('Parser.MDClass')
     tokens = MDLexer.tokens
-    isError = False
+    lexer = None
 
     @_('maybe_newlines name summary description metadata properties')
     def document(self, p):
-        if self.isError:
+        if getattr(self, 'isError', False):
             return None
-        return SpecClass(p.name, p.summary
-        , p.description, p.metadata, p.properties)
+        return SpecClass(p.name, p.summary, p.description, p.metadata, p.properties)
 
     @_('H1 H_TEXTLINE')
     def name(self, p):
@@ -111,7 +122,7 @@ class MDClass(Parser):
 
     @_('ULISTA')
     def metadata_line(self, p):
-        
+
         ulista = p.ULISTA
 
         # strip the md list identifier, ie r'[-*+]'
@@ -122,11 +133,15 @@ class MDClass(Parser):
 
         if len(ulista) != 2:
             # report the invalid syntax
-            self.error(p._slice[0])
+            self.error(p._slice[0], "Syntax Error: Expected `<key>: <values>`")
             return None
 
         _key = ulista[0].strip()
-        _values = re.split(r'\s',ulista[-1].strip())
+        _values = re.split(r'\s', ulista[-1].strip())
+
+        if any(map(lambda x: x.get('name', '') == _key, p[-2])):
+            self.error(
+                p._slice[0], f"Error: Metadata key `{_key}` already exists.")
 
         return {'name': _key, 'values': _values}
 
@@ -143,24 +158,28 @@ class MDClass(Parser):
 
     @_('ULISTA avline_list')
     def single_property(self, p):
-        
+
         ulista = p.ULISTA
 
         # strip the md list identifier, ie r'[-*+]'
         ulista = re.split(r'[-*+]', ulista, 1)[-1].strip()
 
+        if any(map(lambda x: x.get('name', '') == ulista, p[-3])):
+            self.error(
+                p._slice[0], f'Error: Data property `{ulista}` already exists.')
+
         return {'name': ulista, 'values': p.avline_list}
 
     @_('avline_list avline',
-        'avline')
+        'empty')
     def avline_list(self, p):
         if len(p) == 1:
-            return [p.avline]
+            return []
         return p.avline_list + [p.avline]
 
     @_('ULISTB')
     def avline(self, p):
-        
+
         ulistb = p.ULISTB
 
         # strip the md list identifier, ie r'[-*+]'
@@ -171,13 +190,16 @@ class MDClass(Parser):
 
         if len(ulistb) != 2:
             # report the invalid syntax
-            self.error(p._slice[0])
+            self.error(p._slice[0], "Syntax Error: Expected `<key>: <values>`")
             return None
 
         _key = ulistb[0].strip()
-
         # split values by whitespaces
-        _values = re.split(r'\s',ulistb[-1].strip())
+        _values = re.split(r'\s', ulistb[-1].strip())
+
+        if any(map(lambda x: x.get('name', '') == _key, p[-2])):
+            self.error(
+                p._slice[0], f"Error: Attribute key \'{_key}\' already exists")
 
         return {'name': _key, 'values': _values}
 
@@ -202,27 +224,28 @@ class MDClass(Parser):
     @_('newlines',
         'empty')
     def maybe_newlines(self, p):
+        if hasattr(self, 'isError'):
+            self.isError = False
         return None
 
     @_('')
     def empty(self, p):
         return None
 
-    def error(self, p):
-        self.isError = True
-        print('ERROR: ', p)
-        return None
+    def error(self, p, msg=None):
+        parser_error(self, p, msg)
+
 
 class MDProperty(Parser):
 
     # debugfile = 'parser.out'
-    log = logging.getLogger(__name__+'.MDProperty')
+    log = logging.getLogger('Parser.MDProperty')
     tokens = MDLexer.tokens
-    isError = False
+    lexer = None
 
     @_('maybe_newlines name summary description metadata')
     def document(self, p):
-        if self.isError:
+        if getattr(self, 'isError', False):
             return None
         return SpecProperty(p.name, p.summary, p.description, p.metadata)
 
@@ -251,7 +274,7 @@ class MDProperty(Parser):
 
     @_('ULISTA')
     def metadata_line(self, p):
-        
+
         ulista = p.ULISTA
 
         # strip the md list identifier, ie r'[-*+]'
@@ -262,11 +285,15 @@ class MDProperty(Parser):
 
         if len(ulista) != 2:
             # report the invalid syntax
-            self.error(p._slice[0])
+            self.error(p._slice[0], "Syntax Error: Expected `<key>: <values>`")
             return None
 
         _key = ulista[0].strip()
-        _values = re.split(r'\s',ulista[-1].strip())
+        _values = re.split(r'\s', ulista[-1].strip())
+
+        if any(map(lambda x: x.get('name', '') == _key, p[-2])):
+            self.error(
+                p._slice[0], f"Error: Metadata key `{_key}` already exists.")
 
         return {'name': _key, 'values': _values}
 
@@ -291,27 +318,27 @@ class MDProperty(Parser):
     @_('newlines',
         'empty')
     def maybe_newlines(self, p):
+        if hasattr(self, 'isError'):
+            self.isError = False
         return None
 
     @_('')
     def empty(self, p):
         return None
 
-    def error(self, p):
-        self.isError = True
-        print('ERROR: ', p)
-        return None
+    def error(self, p, msg=None):
+        parser_error(self, p, msg)
 
 
 class MDVocab(MDProperty):
     # debugfile = 'parser.out'
-    log = logging.getLogger(f'{__name__}.MDVocab')
+    log = logging.getLogger('Parser.MDVocab')
     tokens = MDLexer.tokens
-    isError = False
+    lexer = None
 
     @_('maybe_newlines name summary description metadata entries')
     def document(self, p):
-        if self.isError:
+        if getattr(self, 'isError', False):
             return None
         return SpecVocab(p.name, p.summary, p.description, p.metadata, p.entries)
 
@@ -340,7 +367,7 @@ class MDVocab(MDProperty):
 
     @_('ULISTA')
     def metadata_line(self, p):
-        
+
         ulista = p.ULISTA
 
         # strip the md list identifier, ie r'[-*+]'
@@ -351,11 +378,15 @@ class MDVocab(MDProperty):
 
         if len(ulista) != 2:
             # report the invalid syntax
-            self.error(p._slice[0])
+            self.error(p._slice[0], "Syntax Error: Expected `<key>: <values>`")
             return None
 
         _key = ulista[0].strip()
-        _values = re.split(r'\s',ulista[-1].strip())
+        _values = re.split(r'\s', ulista[-1].strip())
+
+        if any(map(lambda x: x.get('name', '') == _key, p[-2])):
+            self.error(
+                p._slice[0], f"Error: Metadata key `{_key}` already exists.")
 
         return {'name': _key, 'values': _values}
 
@@ -372,7 +403,7 @@ class MDVocab(MDProperty):
 
     @_('ULISTA')
     def entry_line(self, p):
-        
+
         ulista = p.ULISTA
 
         # strip the md list identifier, ie r'[-*+]'
@@ -383,11 +414,16 @@ class MDVocab(MDProperty):
 
         if len(ulista) != 2:
             # report the invalid syntax
-            self.error(p._slice[0])
+            self.error(
+                p._slice[0], "Syntax Error: Expected `<key>: <description>`")
             return None
 
         _key = ulista[0].strip()
         _value = ulista[-1].strip()
+
+        if any(map(lambda x: x.get('name', '') == _key, p[-2])):
+            self.error(
+                p._slice[0], 'Error: Entry \'{_key}\' already exists')
 
         return {'name': _key, 'value': _value}
 
@@ -412,21 +448,23 @@ class MDVocab(MDProperty):
     @_('newlines',
         'empty')
     def maybe_newlines(self, p):
+        if hasattr(self, 'isError'):
+            self.isError = False
         return None
 
     @_('')
     def empty(self, p):
         return None
 
-    def error(self, p):
-        self.isError = True
-        print('ERROR: ', p)
-        return None
+    def error(self, p, msg=None):
+        parser_error(self, p, msg)
+
 
 if __name__ == '__main__':
 
     lexer = MDLexer()
     parser = MDClass()
+    parser.lexer = lexer
 
     fpath = sys.argv[1]
     # fpath = "spec-v3-template/model/Core/Vocabularies/HashAlgorithmVocab.md"
@@ -438,5 +476,6 @@ if __name__ == '__main__':
     for tok in lexer.tokenize(inp):
         print(tok)
 
+    lexer.fname = fpath
     result = parser.parse(lexer.tokenize(inp))
     result.dump_md('./test.md')

--- a/src/spec_parser.py
+++ b/src/spec_parser.py
@@ -7,11 +7,10 @@ from parser import (
     MDVocab
 )
 from helper import safe_listdir
-from utils import *
 import logging
+from utils import Spec
 
 logger = logging.getLogger(__name__)
-
 __all__ = ['SpecParser']
 
 
@@ -24,6 +23,11 @@ class SpecParser:
         self.mdClass = MDClass()
         self.mdProperty = MDProperty()
         self.mdVocab = MDVocab()
+
+        self.mdClass.lexer = self.lexer
+        self.mdProperty.lexer = self.lexer
+        self.mdVocab.lexer = self.lexer
+
         self.logger = logging.getLogger(self.__class__.__name__)
 
     def parse(self, spec_dir):
@@ -104,6 +108,9 @@ class SpecParser:
         if text is None:
             return None
 
+        self.lexer.fname = fname
+        self.mdClass.fname = fname
+        self.mdClass.text = text
         specClass = self.mdClass.parse(self.lexer.tokenize(text))
 
         if specClass is None:
@@ -118,11 +125,15 @@ class SpecParser:
         if text is None:
             return None
 
+        self.lexer.fname = fname
+        self.mdProperty.fname = fname
+        self.mdProperty.text = text
         specProperty = self.mdProperty.parse(self.lexer.tokenize(text))
 
         if specProperty is None:
             print(fname)
-            self.logger.error(f'Unable to parse `Property` markdown: \'{fname}\'')
+            self.logger.error(
+                f'Unable to parse `Property` markdown: \'{fname}\'')
             return None
 
         return specProperty
@@ -133,10 +144,14 @@ class SpecParser:
         if text is None:
             return None
 
+        self.lexer.fname = fname
+        self.mdVocab.fname = fname
+        self.mdVocab.text = text
         specVocab = self.mdVocab.parse(self.lexer.tokenize(text))
 
         if specVocab is None:
-            self.logger.error(f'Unable to parse `Vocabulary` markdown: \'{fname}\'')
+            self.logger.error(
+                f'Unable to parse `Vocabulary` markdown: \'{fname}\'')
             return None
 
         return specVocab

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,8 +4,8 @@ import re
 from os import path
 from helper import (
     isError,
-    safe_open, 
-    union_dict, 
+    safe_open,
+    union_dict,
     metadata_defaults,
     property_defaults
 )
@@ -28,21 +28,24 @@ class Spec:
         for _class in classes:
             if _class.name in class_dict:
                 # report error
-                self.logger.error('Duplicate `Class` object found: \'{name}:{_class.name}\'')
+                self.logger.error(
+                    'Duplicate `Class` object found: \'{name}:{_class.name}\'')
 
             class_dict[_class.name] = _class
 
         for _prop in properties:
             if _prop.name in props_dict:
                 # report error
-                self.logger.error('Duplicate `Property` object found: \'{name}:{_prop.name}\'')
+                self.logger.error(
+                    'Duplicate `Property` object found: \'{name}:{_prop.name}\'')
 
             props_dict[_prop.name] = _prop
 
         for _vocab in vocabs:
             if _vocab.name in vocabs_dict:
                 # report error
-                self.logger.error('Duplicate `Vocab` object found: \'{name}:{_vocab.name}\'')
+                self.logger.error(
+                    'Duplicate `Vocab` object found: \'{name}:{_vocab.name}\'')
 
             vocabs_dict[_vocab.name] = _vocab
 
@@ -58,7 +61,8 @@ class Spec:
 
         # if we have encounter error then terminate
         if isError():
-            self.logger.warning(f'Error parsing the spec. Aborting the dump_md...')
+            self.logger.warning(
+                f'Error parsing the spec. Aborting the dump_md...')
             return
 
         for namespace_name, namespace in self.namespaces.items():
@@ -106,14 +110,15 @@ class SpecClass:
     def extract_metadata(self, mdata_list):
 
         for _dict in mdata_list:
-            
+
             _key = _dict['name']
             _values = _dict['values']
 
             if _key in self.metadata:
                 # report the error
-                self.logger.error(f'{self.name}: Metadata key \'{_key}\' already exists')
-            
+                self.logger.error(
+                    f'{self.name}: Metadata key \'{_key}\' already exists')
+
             self.metadata[_key] = _values
 
     def extract_properties(self, props_list):
@@ -132,13 +137,15 @@ class SpecClass:
 
                 if _key in subprops_dict:
                     # report the error
-                    self.logger.error(f'{self.name}: Attribute key \'{_key}\' already exists in data property \'{name}\'')
+                    self.logger.error(
+                        f'{self.name}: Attribute key \'{_key}\' already exists in data property \'{name}\'')
 
                 subprops_dict[_key] = _values
 
             if name in self.properties:
                 # report the error
-                self.logger.error(f'{self.name}: Data property \'{_key}\' already exists')
+                self.logger.error(
+                    f'{self.name}: Data property `{_key}` already exists')
 
             self.properties[name] = subprops_dict
 
@@ -204,7 +211,8 @@ class SpecProperty:
 
             if _key in self.metadata:
                 # report the error
-                self.logger.error(f'{self.name}: Metadata key \'{_key}\' already exists')
+                self.logger.error(
+                    f'{self.name}: Metadata key \'{_key}\' already exists')
 
             self.metadata[_key] = _values
 
@@ -264,7 +272,8 @@ class SpecVocab:
 
             if _key in self.metadata:
                 # report the error
-                self.logger.error(f'{self.name}: Metadata key \'{_key}\' already exists')
+                self.logger.error(
+                    f'{self.name}: Metadata key \'{_key}\' already exists')
 
             self.metadata[_key] = _values
 
@@ -277,7 +286,8 @@ class SpecVocab:
 
             if _key in self.entries:
                 # report the error
-                self.logger.error(f'{self.name}: Entry \'{_key}\' already exists')
+                self.logger.error(
+                    f'{self.name}: Entry \'{_key}\' already exists')
 
             self.entries[_key] = _value
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,7 +1,9 @@
 import os
+import logging
 import re
 from os import path
 from helper import (
+    isError,
     safe_open, 
     union_dict, 
     metadata_defaults,
@@ -15,6 +17,7 @@ class Spec:
 
         self.spec_dir = spec_dir
         self.namespaces = dict()
+        self.logger = logging.getLogger(self.__class__.__name__)
 
     def add_namespace(self, name, classes, properties, vocabs):
 
@@ -25,31 +28,38 @@ class Spec:
         for _class in classes:
             if _class.name in class_dict:
                 # report error
-                pass
+                self.logger.error('Duplicate `Class` object found: \'{name}:{_class.name}\'')
+
             class_dict[_class.name] = _class
 
         for _prop in properties:
             if _prop.name in props_dict:
                 # report error
-                pass
+                self.logger.error('Duplicate `Property` object found: \'{name}:{_prop.name}\'')
+
             props_dict[_prop.name] = _prop
 
         for _vocab in vocabs:
             if _vocab.name in vocabs_dict:
                 # report error
-                pass
+                self.logger.error('Duplicate `Vocab` object found: \'{name}:{_vocab.name}\'')
+
             vocabs_dict[_vocab.name] = _vocab
 
         namespace_el = {'name': name, 'classes': class_dict,
                         'properties': props_dict, 'vocabs': vocabs_dict}
 
         if name in self.namespaces:
-            # raiseError(f'ERROR: Namespace with name: {name} already exists')
-            pass
+            self.logger.error(f'Namespace with name: {name} already exists')
 
         self.namespaces[name] = namespace_el
 
     def dump_md(self, out_dir):
+
+        # if we have encounter error then terminate
+        if isError():
+            self.logger.warning(f'Error parsing the spec. Aborting the dump_md...')
+            return
 
         for namespace_name, namespace in self.namespaces.items():
 
@@ -74,6 +84,7 @@ class SpecClass:
 
     def __init__(self, name, summary, description, metadata, props):
 
+        self.logger = logging.getLogger(self.__class__.__name__)
         self.name = name
         self.summary = summary
         self.description = description
@@ -102,7 +113,7 @@ class SpecClass:
             # strip the key and value in metadata entry, ie. <key>: <value>
             ulista = re.split(r':', ulista, 1)
 
-            if len(ulista) != 1:
+            if len(ulista) != 2:
                 # report the invalid syntax
                 pass
 
@@ -111,7 +122,7 @@ class SpecClass:
 
             if _key in self.metadata:
                 # report the error
-                pass
+                self.logger.error(f'{self.name}: Metadata key \'{_key}\' already exists')
             
             self.metadata[_key] = _value
 
@@ -144,13 +155,13 @@ class SpecClass:
 
                 if _key in subprops_dict:
                     # report the error
-                    pass
+                    self.logger.error(f'{self.name}: Attribute key \'{_key}\' already exists in data property \'{name}\'')
 
                 subprops_dict[_key] = _value
 
             if name in self.properties:
                 # report the error
-                pass
+                self.logger.error(f'{self.name}: Data property \'{_key}\' already exists')
 
             self.properties[name] = subprops_dict
 
@@ -217,7 +228,7 @@ class SpecProperty:
             # strip the key and value in metadata entry, ie. <key>: <value>
             ulista = re.split(r':', ulista, 1)
 
-            if len(ulista) != 1:
+            if len(ulista) != 2:
                 # report the invalid syntax
                 pass
 
@@ -226,7 +237,7 @@ class SpecProperty:
 
             if _key in self.metadata:
                 # report the error
-                pass
+                self.logger.error(f'{self.name}: Metadata key \'{_key}\' already exists')
 
             self.metadata[_key] = _value
 
@@ -296,7 +307,7 @@ class SpecVocab:
 
             if _key in self.metadata:
                 # report the error
-                pass
+                self.logger.error(f'{self.name}: Metadata key \'{_key}\' already exists')
 
             self.metadata[_key] = _value
 
@@ -319,7 +330,7 @@ class SpecVocab:
 
             if _key in self.entries:
                 # report the error
-                pass
+                self.logger.error(f'{self.name}: Entry \'{_key}\' already exists')
 
             self.entries[_key] = _value
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -6,9 +6,9 @@ from helper import (
     isError,
     safe_open,
     union_dict,
-    metadata_defaults,
-    property_defaults
+
 )
+from config import id_metadata_prefix, metadata_defaults, property_defaults
 from __version__ import __version__
 
 
@@ -86,9 +86,13 @@ class Spec:
 
 class SpecClass:
 
-    def __init__(self, name, summary, description, metadata, props):
+    def __init__(self, spec, namespace_name, name, summary, description, metadata, props):
 
         self.logger = logging.getLogger(self.__class__.__name__)
+
+        self.spec = spec
+        self.namespace_name = namespace_name
+
         self.name = name
         self.summary = summary
         self.description = description
@@ -98,14 +102,7 @@ class SpecClass:
 
         self.extract_metadata(metadata)
 
-        # add all default metadata fields
-        union_dict(self.metadata, metadata_defaults)
-
         self.extract_properties(props)
-
-        # add all default property fields
-        for val in self.properties.values():
-            union_dict(val, property_defaults)
 
     def extract_metadata(self, mdata_list):
 
@@ -120,6 +117,13 @@ class SpecClass:
                     f'{self.name}: Metadata key \'{_key}\' already exists')
 
             self.metadata[_key] = _values
+
+        # add all default metadata fields
+        union_dict(self.metadata, metadata_defaults)
+
+        # add id metadata
+        self.metadata['id'] = [
+            f'{id_metadata_prefix}{self.namespace_name}#{self.name}']
 
     def extract_properties(self, props_list):
 
@@ -146,6 +150,9 @@ class SpecClass:
                 # report the error
                 self.logger.error(
                     f'{self.name}: Data property `{_key}` already exists')
+
+            # add all default property fields
+            union_dict(subprops_dict, property_defaults)
 
             self.properties[name] = subprops_dict
 
@@ -189,7 +196,12 @@ class SpecClass:
 
 class SpecProperty:
 
-    def __init__(self, name, summary, description, metadata):
+    def __init__(self, spec, namespace_name, name, summary, description, metadata):
+
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+        self.spec = spec
+        self.namespace_name = namespace_name
 
         self.name = name
         self.summary = summary
@@ -198,9 +210,6 @@ class SpecProperty:
         self.metadata = dict()
 
         self.extract_metadata(metadata)
-
-        # add all default metadata fields
-        union_dict(self.metadata, metadata_defaults)
 
     def extract_metadata(self, mdata_list):
 
@@ -215,6 +224,13 @@ class SpecProperty:
                     f'{self.name}: Metadata key \'{_key}\' already exists')
 
             self.metadata[_key] = _values
+
+        # add all default metadata fields
+        union_dict(self.metadata, metadata_defaults)
+
+        # add id metadata
+        self.metadata['id'] = [
+            f'{id_metadata_prefix}{self.namespace_name}#{self.name}']
 
     def dump_md(self, fname):
 
@@ -247,7 +263,12 @@ class SpecProperty:
 
 class SpecVocab:
 
-    def __init__(self, name, summary, description, metadata, entries):
+    def __init__(self, spec, namespace_name, name, summary, description, metadata, entries):
+
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+        self.spec = spec
+        self.namespace_name = namespace_name
 
         self.name = name
         self.summary = summary
@@ -257,9 +278,6 @@ class SpecVocab:
         self.entries = dict()
 
         self.extract_metadata(metadata)
-
-        # add all default metadata fields
-        union_dict(self.metadata, metadata_defaults)
 
         self.extract_entries(entries)
 
@@ -276,6 +294,13 @@ class SpecVocab:
                     f'{self.name}: Metadata key \'{_key}\' already exists')
 
             self.metadata[_key] = _values
+
+        # add all default metadata fields
+        union_dict(self.metadata, metadata_defaults)
+
+        # add id metadata
+        self.metadata['id'] = [
+            f'{id_metadata_prefix}{self.namespace_name}#{self.name}']
 
     def extract_entries(self, entry_list):
 


### PR DESCRIPTION
In this PR, we have used `logging` module to logs relevant information like error, warning and info.

Centralizing logs is useful because we want to print all possible parsing error and any warning (if any), instead of terminating the whole process on first error. This PR helps in getting rid of manual error printing and managing them. 

fixes #16

fixes #22
fixes #14
