### PR TITLE
enable parsing of "## External properties restrictions"

### DIFF
--- a/spec_parser/utils.py
+++ b/spec_parser/utils.py
@@ -313,7 +313,8 @@ class SpecClass(SpecBase):
         description: str,
         metadata: dict,
         props: dict,
-        license_name: str
+        license_name: str,
+        external_properties_restrictions: dict
     ):
 
         super().__init__(


### PR DESCRIPTION
The spec-parser pipeline currently fails because the new heading "## External properties restrictions" is not recognized. This PR fixes that.
I only implemented this as far as the constructor of `SpecClass`, from where this can be taken further when the property is actually needed.