### PR TITLE
[issue_42] exit system with code 1 if any error was logged during parsing

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,8 @@
 import os
 import logging
+import sys
 from argparse import ArgumentParser
-from spec_parser import SpecParser
+from spec_parser import SpecParser, isError
 
 
 def get_args():
@@ -54,6 +55,9 @@ if __name__ == "__main__":
 
     specParser = SpecParser(**vars(args))
     spec = specParser.parse(args.spec_dir)
+    if isError():
+        logging.error(f"Spec not parsed successfully.")
+        exit(1)
     if args.gen_md:
         spec.gen_md()
     if args.gen_rdf:

--- a/spec_parser/utils.py
+++ b/spec_parser/utils.py
@@ -107,10 +107,6 @@ class Spec:
 
     def gen_md(self) -> None:
         """Generate pretty markdowns."""
-        # if we have encounter error then terminate
-        if isError():
-            self.logger.warning(f"Specs not parsed succesfully, aborting the gen_md...")
-            return
 
         if path.isdir(self.args["out_dir"]):
             self.logger.warning(f"Overwriting out_dir `{self.args['out_dir']}`")
@@ -160,11 +156,6 @@ class Spec:
 
             for vocab_obj in vocabs.values():
                 vocab_obj._gen_rdf(g)
-
-        # if we have encounter error then terminate
-        if isError():
-            self.logger.warning(f"Error parsing the spec. Aborting the gen_rdf...")
-            return
 
         fname = path.join(self.args["out_dir"], f"model.ttl")
         with safe_open(fname, "w") as f:


### PR DESCRIPTION
I also deleted the calls to `isError()` and the early return in `gen_md()` and  `gen_rdf()` as they wouldn't do anything. I am a bit confused why this call is after the generation of the graph in `gen_rdf()` but as the graph wouldn't be serialized anyway, I guess it is alright to exit the system before calling `gen_rdf()`. 

fixes #42 
