### PR TITLE
Fix: generate correct URIs for entities with "/"

### DIFF
--- a/spec_parser/utils.py
+++ b/spec_parser/utils.py
@@ -274,7 +274,9 @@ class SpecBase:
         if ":" in entity:
             namespace_and_entity = re.split(r":", entity)
         elif "/" in entity:
-            namespace_and_entity = re.split(r"/", entity)[1:]
+            entity_split_in_single_elements = re.split(r"/", entity)
+            namespace_and_entity = entity_split_in_single_elements if entity_split_in_single_elements[0] else \
+                entity_split_in_single_elements[1:]
         else:
             namespace_and_entity = [self.namespace_name,  entity]
 

--- a/spec_parser/utils.py
+++ b/spec_parser/utils.py
@@ -268,26 +268,28 @@ class SpecBase:
             self.entries[_key] = _value
 
     def _gen_uri(self, entity):
-
-        splitted = re.split(r":", entity)
-
-        if len(splitted) > 2:
+        if getattr(self, "spec", None) is None:
             return Literal(entity)
 
-        if getattr(self, "spec", None) is None:
+        if ":" in entity:
+            namespace_and_entity = re.split(r":", entity)
+        elif "/" in entity:
+            namespace_and_entity = re.split(r"/", entity)[1:]
+        else:
+            namespace_and_entity = [self.namespace_name,  entity]
+
+        if len(namespace_and_entity) > 2:
+            self.logger.warning(f"Unrecognized reference: {entity}")
             return Literal(entity)
 
         rdf_dict = self.spec.rdf_dict
 
-        if len(splitted) == 1:
-            _namespace = self.namespace_name
-        else:
-            _namespace = splitted[0]
+        _namespace = namespace_and_entity[0]
 
         if _namespace not in rdf_dict:
             return Literal(entity)
 
-        return rdf_dict[_namespace][splitted[-1]]
+        return rdf_dict[_namespace][namespace_and_entity[-1]]
 
 
 class SpecClass(SpecBase):

--- a/spec_parser/utils.py
+++ b/spec_parser/utils.py
@@ -272,26 +272,21 @@ class SpecBase:
             return Literal(entity)
 
         if ":" in entity:
-            namespace_and_entity = re.split(r":", entity)
-        elif "/" in entity:
-            entity_split_in_single_elements = re.split(r"/", entity)
-            namespace_and_entity = entity_split_in_single_elements if entity_split_in_single_elements[0] else \
-                entity_split_in_single_elements[1:]
+            [_namespace, _entity] = re.split(r":", entity)
         else:
-            namespace_and_entity = [self.namespace_name,  entity]
-
-        if len(namespace_and_entity) > 2:
-            self.logger.warning(f"Unrecognized reference: {entity}")
-            return Literal(entity)
+            namespace_and_entity = entity.lstrip('/').rsplit('/', 1)
+            if len(namespace_and_entity) == 1:
+                _entity = namespace_and_entity[0]
+                _namespace = self.namespace_name
+            else:
+                [_namespace, _entity] = namespace_and_entity
 
         rdf_dict = self.spec.rdf_dict
-
-        _namespace = namespace_and_entity[0]
 
         if _namespace not in rdf_dict:
             return Literal(entity)
 
-        return rdf_dict[_namespace][namespace_and_entity[-1]]
+        return rdf_dict[_namespace][_entity]
 
 
 class SpecClass(SpecBase):


### PR DESCRIPTION
Some entitities contain slash notation to reference elements in different namespaces which lead to incorrect URIs. With this PR besides `:` also `/` are taken into account and treated different when generating URIs.