### PR TITLE
#47 parse format section

### DIFF
--- a/spec_parser/config.py
+++ b/spec_parser/config.py
@@ -3,6 +3,7 @@ id_metadata_prefix = 'https://spdx.org/rdf/'
 valid_metadata_key = ['name', 'SubclassOf',
                       'Nature', 'Range', 'Instantiability', 'Status']
 valid_dataprop_key = ['type', 'minCount', 'maxCount']
+valid_format_key = ['pattern']
 
 metadata_defaults = {'Instantiability': ['Concrete'], 'Status': ['Stable']}
 property_defaults = {'minCount': ['0'], 'maxCount': ['*']}

--- a/spec_parser/helper.py
+++ b/spec_parser/helper.py
@@ -89,3 +89,7 @@ def union_dict(d1: dict, d2: dict) -> dict:
     for k, v in d2.items():
         if not k in d1:
             d1[k] = v
+
+
+def reg_ex_for_section(title: str) -> str:
+    return r"((?<=\n)|^)\#{2}\s+" + title + r"(?:(?!\n)\s)*(\n+|$)"

--- a/spec_parser/helper.py
+++ b/spec_parser/helper.py
@@ -2,8 +2,8 @@ import os
 import re
 import logging
 from os import path
-from typing import List
-from .config import id_metadata_prefix
+from typing import List, Tuple
+from .config import valid_metadata_key, valid_format_key
 
 
 def addErrorFilter(logger: logging.Logger) -> None:
@@ -93,3 +93,12 @@ def union_dict(d1: dict, d2: dict) -> dict:
 
 def reg_ex_for_section(title: str) -> str:
     return r"((?<=\n)|^)\#{2}\s+" + title + r"(?:(?!\n)\s)*(\n+|$)"
+
+
+def determine_section_title(parsed_title: str) -> Tuple[List[str], str]:
+    if "Metadata" in parsed_title:
+        return valid_metadata_key, "metadata"
+    elif "Format" in parsed_title:
+        return valid_format_key, "format"
+    else:
+        logging.error("Parsed section is neither metadata nor format.")

--- a/spec_parser/parser.py
+++ b/spec_parser/parser.py
@@ -3,6 +3,8 @@ import re
 import sys
 import sly
 from sly import Parser, Lexer
+
+from spec_parser.helper import reg_ex_for_section
 from .config import valid_dataprop_key, valid_metadata_key
 
 __all__ = ["MDLexer", "MDClass", "MDProperty", "MDVocab"]
@@ -66,14 +68,14 @@ class MDLexer(Lexer):
 
     ignore_comment = r"(?:(?!\n)\s)*<!?--(?:(?!-->)(.|\n|\s))*-->(?:(?!\n)\s)*\n*"
 
-    SUMMARY = r"((?<=\n)|^)\#{2}\s+Summary(?:(?!\n)\s)*(\n+|$)"
-    DESCRIPTION = r"((?<=\n)|^)\#{2}\s+Description(?:(?!\n)\s)*(\n+|$)"
-    METADATA = r"((?<=\n)|^)\#{2}\s+Metadata(?:(?!\n)\s)*(\n+|$)"
-    PROPERTIES = r"((?<=\n)|^)\#{2}\s+Properties(?:(?!\n)\s)*(\n+|$)"
-    FORMAT = r"((?<=\n)|^)\#{2}\s+Format(?:(?!\n)\s)*(\n+|$)"
-    ENTRIES = r"((?<=\n)|^)\#{2}\s+Entries(?:(?!\n)\s)*(\n+|$)"
+    SUMMARY = reg_ex_for_section("Summary")
+    DESCRIPTION = reg_ex_for_section("Description")
+    METADATA = reg_ex_for_section("Metadata")
+    PROPERTIES = reg_ex_for_section("Properties")
+    FORMAT = reg_ex_for_section("Format")
+    ENTRIES = reg_ex_for_section("Entries")
     LICENSE = r"((?<=\n)|^)\s*SPDX-License-Identifier\s*:[^\n]+(?:(?!\n)\s)*(\n+|$)"
-    EXT_PROPERTIES = r"((?<=\n)|^)\#{2}\s+External properties restrictions(?:(?!\n)\s)*(\n+|$)"
+    EXT_PROPERTIES = reg_ex_for_section("External properties restrictions")
 
     H6 = r"((?<=\n)|^)\s*\#{6}"
     H5 = r"((?<=\n)|^)\s*\#{5}"
@@ -126,7 +128,7 @@ class MDClass(Parser):
             # report the invalid syntax
             self.error(p._slice[0], "Syntax Error: Expected `SPDX-License-Identifier: <value>`")
             return None
-        
+
         license_name = splitted[-1].strip()
         return license_name
 
@@ -293,6 +295,7 @@ class MDClass(Parser):
         format_regex = re.split(r"pattern:\s", ulista, 1)[1]
 
         return {"pattern": format_regex}
+
     @_("para para_line", "empty")
     def para(self, p):
         if len(p) == 1:
@@ -348,7 +351,7 @@ class MDProperty(Parser):
             # report the invalid syntax
             self.error(p._slice[0], "Syntax Error: Expected `SPDX-License-Identifier: <value>`")
             return None
-        
+
         license_name = splitted[-1].strip()
         return license_name
 
@@ -474,7 +477,7 @@ class MDVocab(MDProperty):
             # report the invalid syntax
             self.error(p._slice[0], "Syntax Error: Expected `SPDX-License-Identifier: <value>`")
             return None
-        
+
         license_name = splitted[-1].strip()
         return license_name
 
@@ -487,7 +490,7 @@ class MDVocab(MDProperty):
         if p[0] is None:
             return ""
         return p[0]
-    
+
     @_("SUMMARY para")
     def summary(self, p):
         return p.para.strip()

--- a/spec_parser/utils.py
+++ b/spec_parser/utils.py
@@ -335,8 +335,21 @@ class SpecClass(SpecBase):
         self._extract_properties(props)
         self.format_pattern = format_pattern
         self.ext_props = ext_props
+        if ext_props:
+            self.logger.warning("External property restrictions aren't yet handled properly, they are added to the "
+                                "description of the class.")
+            for ext_prop in self.ext_props:
+                for value in ext_prop["values"]:
+                    self.description += f"\nExternal property restriction on {ext_prop['name']}: {value['name']}: " \
+                                        f"{' '.join(value['values'])}"
+
+        if format_pattern:
+            self.logger.warning("Format restrictions aren't yet handled properly, they are added to the "
+                                "description of the class.")
+            self.description += f"\nFormat pattern: {self.format_pattern['pattern']}"
 
     # TODO: handle ext_props in some way -- for now, silently ignored
+    # TODO: handle format_pattern in some way -- for now, silently ignored
 
     def _gen_md(self, args: dict) -> None:
 

--- a/spec_parser/utils.py
+++ b/spec_parser/utils.py
@@ -51,7 +51,7 @@ class Spec:
         self.args.setdefault("out_dir", "md_generated")
 
     def add_namespace(
-        self, name: str, classes: List, properties: List, vocabs: List
+            self, name: str, classes: List, properties: List, vocabs: List
     ) -> None:
         """Add namespace information into Specfication.
 
@@ -174,13 +174,13 @@ class Spec:
 
 class SpecBase:
     def __init__(
-        self,
-        spec: Spec,
-        namespace_name: str,
-        name: str,
-        summary: str,
-        description: str,
-        license_name: str
+            self,
+            spec: Spec,
+            namespace_name: str,
+            name: str,
+            summary: str,
+            description: str,
+            license_name: str
     ):
 
         self.logger: logging.Logger = None
@@ -308,8 +308,18 @@ class SpecClass(SpecBase):
         license_name (str): license provided through SPDX-License-Identifier
     """
 
-    def __init__(self, spec: Spec, namespace_name: str, name: str, summary: str, description: str, metadata: dict,
-                 props: dict, format_pattern: dict, ext_props: dict, license_name: str):
+    def __init__(
+            self,
+            spec: Spec,
+            namespace_name: str,
+            name: str,
+            summary: str,
+            description: str,
+            metadata: dict,
+            props: dict,
+            format_pattern: dict,
+            ext_props: dict,
+            license_name: str):
 
         super().__init__(
             spec,
@@ -325,7 +335,8 @@ class SpecClass(SpecBase):
         self._extract_properties(props)
         self.format_pattern = format_pattern
         self.ext_props = ext_props
-# TODO: handle ext_props in some way -- for now, silently ignored
+
+    # TODO: handle ext_props in some way -- for now, silently ignored
 
     def _gen_md(self, args: dict) -> None:
 
@@ -390,7 +401,6 @@ class SpecClass(SpecBase):
                 f.write(f"## Format\n\n")
                 f.write(f"- pattern: {self.format_pattern['pattern']}\n")
 
-
             # license declaration
             f.write(f"\nSPDX-License-Identifier: {self.license_name}")
 
@@ -440,14 +450,14 @@ class SpecProperty(SpecBase):
     """
 
     def __init__(
-        self,
-        spec: Spec,
-        namespace_name: str,
-        name: str,
-        summary: str,
-        description: str,
-        metadata: dict,
-        license_name: str
+            self,
+            spec: Spec,
+            namespace_name: str,
+            name: str,
+            summary: str,
+            description: str,
+            metadata: dict,
+            license_name: str
     ):
 
         super().__init__(
@@ -551,15 +561,15 @@ class SpecVocab(SpecBase):
     """
 
     def __init__(
-        self,
-        spec: Spec,
-        namespace_name: str,
-        name: str,
-        summary: str,
-        description: str,
-        metadata: dict,
-        entries: dict,
-        license_name: str,
+            self,
+            spec: Spec,
+            namespace_name: str,
+            name: str,
+            summary: str,
+            description: str,
+            metadata: dict,
+            entries: dict,
+            license_name: str,
     ):
 
         super().__init__(

--- a/spec_parser/utils.py
+++ b/spec_parser/utils.py
@@ -303,20 +303,13 @@ class SpecClass(SpecBase):
         description (str): description of this entity
         metadata (dict): metadata of this entity
         props (dict): properties of this entity
+        format_pattern (dict): format specification of this entity
+        ext_props (dict): restrictions on external properties for this entity
+        license_name (str): license provided through SPDX-License-Identifier
     """
 
-    def __init__(
-        self,
-        spec: Spec,
-        namespace_name: str,
-        name: str,
-        summary: str,
-        description: str,
-        metadata: dict,
-        props: dict,
-        ext_props: dict,
-        license_name: str
-    ):
+    def __init__(self, spec: Spec, namespace_name: str, name: str, summary: str, description: str, metadata: dict,
+                 props: dict, format_pattern: dict, ext_props: dict, license_name: str):
 
         super().__init__(
             spec,
@@ -330,6 +323,8 @@ class SpecClass(SpecBase):
         self.logger = logging.getLogger(self.__class__.__name__)
         self._extract_metadata(metadata)
         self._extract_properties(props)
+        self.format_pattern = format_pattern
+        self.ext_props = ext_props
 # TODO: handle ext_props in some way -- for now, silently ignored
 
     def _gen_md(self, args: dict) -> None:
@@ -391,6 +386,10 @@ class SpecClass(SpecBase):
                     for _key, subprop in subprops.items():
                         f.write(f'  - {_key}: {" ".join(subprop)}\n')
                     f.write("\n")
+            if self.format_pattern:
+                f.write(f"## Format\n\n")
+                f.write(f"- pattern: {self.format_pattern['pattern']}\n")
+
 
             # license declaration
             f.write(f"\nSPDX-License-Identifier: {self.license_name}")


### PR DESCRIPTION
This PR adds functionality to parse the new format section in the markdown files. The parsed data will also be written when generating the markdown files but I didn't know where to put the parsed information in the generated `model.ttl`. With this PR the CI in the spdx-3-model should be fixed. 

part of #47