### PR TITLE
skip none values to avoid missing references

### DIFF
--- a/spec_parser/utils.py
+++ b/spec_parser/utils.py
@@ -205,6 +205,9 @@ class SpecBase:
                 # report the error
                 self.logger.error(f"{self.name}: Metadata key '{_key}' already exists")
 
+            if _values == ["none"]:  # for some classes subClass is set to none, skip these
+                continue
+
             self.metadata[_key] = _values
 
         # add all default metadata fields

--- a/spec_parser/utils.py
+++ b/spec_parser/utils.py
@@ -205,10 +205,8 @@ class SpecBase:
                 # report the error
                 self.logger.error(f"{self.name}: Metadata key '{_key}' already exists")
 
-            if _values == ["none"]:  # for some classes subClass is set to none, skip these
-                continue
-
-            self.metadata[_key] = _values
+            if _values != ["none"]:  # for some classes subClass is set to none
+                self.metadata[_key] = _values
 
         # add all default metadata fields
         union_dict(self.metadata, metadata_defaults)


### PR DESCRIPTION
I had a look at ontospy and noticed that many classes were subclasses of `core:none` as this is written in the markdown files. I think we should skip these values to avoid a wrong reference. 