### PR TITLE
Add value to property keys

### DIFF
--- a/docs/md_docs/error_checks.md
+++ b/docs/md_docs/error_checks.md
@@ -34,3 +34,4 @@ If the Data-property attribute key doesn't match the following list, error is re
 - `type`
 - `minCount`
 - `maxCount`
+- `value`

--- a/spec_parser/config.py
+++ b/spec_parser/config.py
@@ -2,7 +2,7 @@ id_metadata_prefix = 'https://spdx.org/rdf/'
 
 valid_metadata_key = ['name', 'SubclassOf',
                       'Nature', 'Range', 'Instantiability', 'Status']
-valid_dataprop_key = ['type', 'minCount', 'maxCount']
+valid_dataprop_key = ['type', 'minCount', 'maxCount', 'value']
 valid_format_key = ['pattern']
 
 metadata_defaults = {'Instantiability': ['Concrete'], 'Status': ['Stable']}


### PR DESCRIPTION
This PR adds a new key to the recognized properties, "value".

The idea of having this entry is to be able to recognize a fixed value of a property. For example:

```
## Properties

- relationshipType
  - type: relationshipType
  - value: underInvestigationFor

```