### PR TITLE
Add domain to properties

### DIFF
--- a/spec_parser/spec_parser.py
+++ b/spec_parser/spec_parser.py
@@ -259,9 +259,9 @@ class SpecParser:
         return inp
 
 
-def assign_domain_to_property(specProperty: SpecProperty, classes: List[SpecClass]):
+def assign_domain_to_property(spec_property: SpecProperty, classes: List[SpecClass]):
     for spec_class in classes:
-        for _property in spec_class.properties:
-            if _property == specProperty.name:
-                specProperty.metadata.setdefault("Domain", []).append(spec_class.name)
+        _property = spec_class.properties.get(spec_property.name)
+        if _property:
+            spec_property.metadata.setdefault("Domain", []).append(spec_class.name)
 

--- a/spec_parser/spec_parser.py
+++ b/spec_parser/spec_parser.py
@@ -2,7 +2,7 @@ import os
 import re
 import os.path as path
 from .parser import MDClass, MDLexer, MDProperty, MDVocab
-from typing import Optional, Union
+from typing import Optional, List
 from .helper import safe_listdir
 import logging
 from .utils import Spec, SpecClass, SpecProperty, SpecVocab
@@ -95,6 +95,9 @@ class SpecParser:
 
                 if specProperty is None:
                     continue
+
+                # add domain to property according to the definitions in class objects
+                assign_domain_to_property(specProperty, classes)
 
                 properties.append(specProperty)
 
@@ -254,3 +257,11 @@ class SpecParser:
             inp = f.read()
 
         return inp
+
+
+def assign_domain_to_property(specProperty: SpecProperty, classes: List[SpecClass]):
+    for spec_class in classes:
+        for _property in spec_class.properties:
+            if _property == specProperty.name:
+                specProperty.metadata.setdefault("Domain", []).append(spec_class.name)
+

--- a/spec_parser/utils.py
+++ b/spec_parser/utils.py
@@ -556,8 +556,17 @@ class SpecProperty(SpecBase):
         for _val in self.metadata.get("Range", []):
             g.add((cur, RDFS.range, self._gen_uri(_val)))
 
-        for _val in self.metadata.get("Domain", []):
-            g.add((cur, RDFS.domain, self._gen_uri(_val)))
+        if len(self.metadata.get("Domain", [])) > 1:
+            orNode = BNode()
+            g.add((cur, SH["or"], orNode))
+            first_node = BNode()
+            g.add((orNode, RDF.first, first_node))
+            g.add((orNode, RDF.rest, RDF.nil))
+            for _val in self.metadata.get("Domain", []):
+                g.add((first_node, RDFS.domain, self._gen_uri(_val)))
+        else:
+            for _val in self.metadata.get("Domain", []):
+                g.add((cur, RDFS.domain, self._gen_uri(_val)))
 
         g.add((cur, RDFS.comment, Literal(self.description)))
         g.add((cur, NS0.term_status, Literal(self.metadata.get("Status")[0])))


### PR DESCRIPTION
This PR adds a domain to a property based on the definitions in the corresponding class markdown files. If a property is used in multiple classes we need to add a `sh:or` node to express that the property is part of the one or the other class, so to use a logical or, simply adding multiple domains would express a conjunction (see the [documentation](https://www.w3.org/TR/owl-ref/#domain-def)).

The main reason to add the domains is that `Ontospy` is then able to fill the `Usage` table with the properties of a class as in the attached screenshot.  
![image](https://github.com/spdx/spec-parser/assets/50019307/eed6bd40-b05d-4313-b0bf-aba598c3a1f2)