### PR TITLE
add json dump

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,12 +1,11 @@
-import os
 import logging
-import sys
+import os
 from argparse import ArgumentParser
+
 from spec_parser import SpecParser, isError
 
 
 def get_args():
-
     argparser = ArgumentParser(
         prog="spec-parser", description="SPDX specification parser"
     )
@@ -17,6 +16,12 @@ def get_args():
 
     argparser.add_argument(
         "--gen-refs", action="store_true", help="Generate References list for Property"
+    )
+
+    argparser.add_argument(
+        "--json-dump",
+        action="store_true",
+        help="Dump the JSON representation of the markdown files.",
     )
 
     argparser.add_argument(
@@ -58,6 +63,8 @@ if __name__ == "__main__":
     if isError():
         logging.error(f"Spec not parsed successfully.")
         exit(1)
+    if args.json_dump:
+        spec.gen_json_dump()
     if args.gen_md:
         spec.gen_md()
     if args.gen_rdf:

--- a/spec_parser/utils.py
+++ b/spec_parser/utils.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import re
 from os import path
@@ -176,6 +177,10 @@ class Spec:
         fname = path.join(self.args["out_dir"], f"model.ttl")
         with safe_open(fname, "w") as f:
             f.write(g.serialize(format="turtle"))
+
+    def gen_json_dump(self) -> None:
+        with safe_open(path.join(self.args["out_dir"], f"model_dump.json"), "w") as f:
+            f.write(json.dumps(self.namespaces, default=spec_to_json_encoder))
 
 
 class SpecBase:
@@ -696,3 +701,21 @@ class SpecVocab(SpecBase):
             uri = cur + "/" + _entry
             g.add((uri, RDF.type, OWL.NamedIndividual))
             g.add((uri, RDF.type, cur))
+
+
+def spec_to_json_encoder(spec_obj):
+    if isinstance(spec_obj, SpecClass):
+        return {"summary": spec_obj.summary,
+                "description": spec_obj.description,
+                "metadata": spec_obj.metadata,
+                "properties": spec_obj.properties}
+    if isinstance(spec_obj, SpecProperty):
+        return {"summary": spec_obj.summary,
+                "description": spec_obj.description,
+                "metadata": spec_obj.metadata}
+    if isinstance(spec_obj, SpecVocab):
+        return {"summary": spec_obj.summary,
+                "description": spec_obj.description,
+                "metadata": spec_obj.metadata,
+                "entries": spec_obj.entries}
+    return spec_obj


### PR DESCRIPTION
This adds an option to dump the parsed spec information into a json file. This will enable anyone to easily create something from the specification without having to parse the markdown files first.
