### PR TITLE
Fix issues in RDF model output concerning property constraints and vocab instances

### DIFF
--- a/spec_parser/utils.py
+++ b/spec_parser/utils.py
@@ -450,6 +450,9 @@ class SpecClass(SpecBase):
         sh_class = URIRef("http://www.w3.org/ns/shacl#class")
 
         for prop_name, prop_value in self.properties.items():
+            if prop_name == "spdxId":
+                # the @id field in RDF already fulfils the function of this field
+                continue
             property_uri = self._gen_uri(prop_name)
             property_type_uri = self._gen_uri(prop_value["type"][0])
             min_count: str = prop_value["minCount"][0]
@@ -679,6 +682,5 @@ class SpecVocab(SpecBase):
         # add entries
         for _entry, _desc in self.entries.items():
             uri = cur + "/" + _entry
-            print("Vocab entry", _entry, uri)
             g.add((uri, RDF.type, OWL.NamedIndividual))
             g.add((uri, RDF.type, cur))

--- a/spec_parser/utils.py
+++ b/spec_parser/utils.py
@@ -658,5 +658,7 @@ class SpecVocab(SpecBase):
 
         # add entries
         for _entry, _desc in self.entries.items():
-            g.add((self._gen_uri(_entry), RDF.type, OWL.NamedIndividual))
-            g.add((self._gen_uri(_entry), RDF.type, cur))
+            uri = cur + "/" + _entry
+            print("Vocab entry", _entry, uri)
+            g.add((uri, RDF.type, OWL.NamedIndividual))
+            g.add((uri, RDF.type, cur))

--- a/spec_parser/utils.py
+++ b/spec_parser/utils.py
@@ -165,6 +165,9 @@ class Spec:
                 class_obj._gen_rdf(g, class_types)
 
             for prop_obj in properties.values():
+                if prop_obj.name == "spdxId":
+                    # the @id field in RDF already fulfils the function of this field
+                    continue
                 prop_obj._gen_rdf(g)
 
             for vocab_obj in vocabs.values():

--- a/spec_parser/utils.py
+++ b/spec_parser/utils.py
@@ -131,7 +131,7 @@ class Spec:
         for _namespace in self.namespaces.values():
             classes = _namespace["classes"]
             vocabs = _namespace["vocabs"]
-            class_types += [URIRef(c.metadata["id"][0]) for c in classes.values()]
+            class_types += [URIRef(c.metadata["id"][0]) for c in classes.values() if not c.is_literal()]
             class_types += [URIRef(v.metadata["id"][0]) for v in vocabs.values()]
 
         return class_types
@@ -468,6 +468,9 @@ class SpecClass(SpecBase):
                 g.add((restriction_node, SH.maxCount, Literal(int(max_count))))
 
             g.add((cur, SH.property, restriction_node))
+
+    def is_literal(self) -> bool:
+        return len(self.properties) == 0 and "xsd:string" in self.metadata.get("SubclassOf", [])
 
 
 class SpecProperty(SpecBase):


### PR DESCRIPTION
While experimenting with json-ld serialization and shacl validation, we noticed a couple of errors in the generated RDF module. This PR aims to fix the following issues:

- instances of vocabulary types were generated with the wrong URI, which was missing the vocabulary type as a prefix
- `sh:datatype` was used as a constraint for all class properties, but it only works for literal types. For our complex types, `sh:class` needs to be used, instead. (In some instances, like `PositiveIntegerRange`, `sh:node` might be better / more convenient, but `sh:class` at least works.)
- `spdxId` was included as a required property, even though RDF already has the `@id` field that should be used instead.