### PR TITLE
use `EnumeratedClass` to add Enumeration classes to the RDF graph

### DIFF
--- a/spec_parser/utils.py
+++ b/spec_parser/utils.py
@@ -6,6 +6,7 @@ from typing import List
 
 import rdflib
 from rdflib import URIRef, Literal, BNode, SH
+from rdflib.extras.infixowl import EnumeratedClass
 from rdflib.namespace import RDF, OWL, RDFS, XSD
 
 NS0 = rdflib.Namespace("http://www.w3.org/2003/06/sw-vocab-status/ns#")
@@ -706,16 +707,19 @@ class SpecVocab(SpecBase):
     def _gen_rdf(self, g: rdflib.Graph):
 
         cur = URIRef(self.metadata["id"])
-        g.add((cur, RDF.type, OWL["Class"]))
 
         g.add((cur, RDFS.comment, Literal(self.description)))
         g.add((cur, NS0.term_status, Literal(self.metadata.get("Status"))))
 
         # add entries
+        entries = set()
         for _entry, _desc in self.entries.items():
             uri = cur + "/" + _entry
+            entries.add(uri)
             g.add((uri, RDF.type, OWL.NamedIndividual))
             g.add((uri, RDF.type, cur))
+
+        EnumeratedClass(cur, entries, g)
 
 
 def spec_to_json_encoder(spec_obj):


### PR DESCRIPTION
This will result in an `owl:oneOf` restriction in the ontology like so:
```
core:HashAlgorithm a owl:Class ;
    rdfs:comment """A HashAlgorithm is a mathematical algorithm that maps data of arbitrary size to a bit string (the hash)
and is a one-way function, that is, a function which is practically infeasible to invert.""" ;
    owl:oneOf ( <https://spdx.org/rdf/v3/Core/HashAlgorithm/blake2b256> <https://spdx.org/rdf/v3/Core/HashAlgorithm/blake2b384> <https://spdx.org/rdf/v3/Core/HashAlgorithm/blake2b512> <https://spdx.org/rdf/v3/Core/HashAlgorithm/blake3> <https://spdx.org/rdf/v3/Core/HashAlgorithm/crystalsKyber> <https://spdx.org/rdf/v3/Core/HashAlgorithm/crystalsDilithium> <https://spdx.org/rdf/v3/Core/HashAlgorithm/falcon> <https://spdx.org/rdf/v3/Core/HashAlgorithm/md2> <https://spdx.org/rdf/v3/Core/HashAlgorithm/md4> <https://spdx.org/rdf/v3/Core/HashAlgorithm/md5> <https://spdx.org/rdf/v3/Core/HashAlgorithm/md6> <https://spdx.org/rdf/v3/Core/HashAlgorithm/other> <https://spdx.org/rdf/v3/Core/HashAlgorithm/sha1> <https://spdx.org/rdf/v3/Core/HashAlgorithm/sha224> <https://spdx.org/rdf/v3/Core/HashAlgorithm/sha256> <https://spdx.org/rdf/v3/Core/HashAlgorithm/sha3_224> <https://spdx.org/rdf/v3/Core/HashAlgorithm/sha3_256> <https://spdx.org/rdf/v3/Core/HashAlgorithm/sha3_384> <https://spdx.org/rdf/v3/Core/HashAlgorithm/sha3_512> <https://spdx.org/rdf/v3/Core/HashAlgorithm/sha384> <https://spdx.org/rdf/v3/Core/HashAlgorithm/sha512> <https://spdx.org/rdf/v3/Core/HashAlgorithm/spdxPvcSha1> <https://spdx.org/rdf/v3/Core/HashAlgorithm/spdxPvcSha256> <https://spdx.org/rdf/v3/Core/HashAlgorithm/sphincsPlus> ) ;
    ns0:term_status "Stable" .
```
As a further step, we might want to adapt the code to use namespace identifiers instead of full URIs.