### PR TITLE
Specify encoding on file open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ docs/_build
 *ehthumbs.db
 *Icon?
 *Thumbs.db
+
+# Virtual Env        #
+######################
+venv

--- a/spec_parser/spec_parser.py
+++ b/spec_parser/spec_parser.py
@@ -253,7 +253,7 @@ class SpecParser:
             self.logger(f"No such file exists: '{fname}'")
             return None
 
-        with open(fname, "r") as f:
+        with open(fname, "r", encoding="utf-8") as f:
             inp = f.read()
 
         return inp


### PR DESCRIPTION
This allows the spec-parser to be run on windows where the default encoding is not UTF-8.

Also updated the .gitignore to ignore any venv folders