### PR TITLE
Change dictsort in property template

### DIFF
--- a/spec_parser/templates/default/property.md.j2
+++ b/spec_parser/templates/default/property.md.j2
@@ -17,7 +17,7 @@
 
 {% if args.get("gen_refs", False) %}
     ## References
-    {% for name in spec.dataprop_refs.get(self.name, []) | dictsort %}
+    {% for name in spec.dataprop_refs.get(self.name, []) | sort %}
         - {{name}}
     {% endfor %}
 {% endif %}


### PR DESCRIPTION
Fixes a failure when running the spec-parser against the current release