### PR TITLE
Fix unhandled AttributeError on mdparsing

### DIFF
--- a/spec_parser/mdparsing.py
+++ b/spec_parser/mdparsing.py
@@ -36,12 +36,15 @@ class SpecFile():
             self.name = m.group(1)
 
         for p in parts[2:]:
-            if p.strip():
-                m = re.fullmatch(self.RE_EXTRACT_HEADER_CONTENT, p)
-                header = m.group(1)
-                content = m.group(2).strip()
-                if content:
-                    self.sections[header] = content
+            if p.strip() == "":
+                continue
+            m = re.fullmatch(self.RE_EXTRACT_HEADER_CONTENT, p)
+            if m is None:
+                continue
+            header = m.group(1)
+            content = m.group(2).strip()
+            if content:
+                self.sections[header] = content
 
 
 


### PR DESCRIPTION
This commit fixes an unhandled atrrtibute error when parsing markdown headers:

```
python ./main.py -n ../spdx-3-model/model/ 
Traceback (most recent call last):
  File "/home/urbano/Projects/spdx/spec-parser/./main.py", line 11, in <module>
    m = Model(cfg.input_dir)
        ^^^^^^^^^^^^^^^^^^^^
  File "/home/urbano/Projects/spdx/spec-parser/spec_parser/model.py", line 28, in __init__
    self.load(dir)
  File "/home/urbano/Projects/spdx/spec-parser/spec_parser/model.py", line 50, in load
    n = Class(f, ns)
        ^^^^^^^^^^^^
  File "/home/urbano/Projects/spdx/spec-parser/spec_parser/model.py", line 153, in __init__
    sf = SpecFile(fname)
         ^^^^^^^^^^^^^^^
  File "/home/urbano/Projects/spdx/spec-parser/spec_parser/mdparsing.py", line 18, in __init__
    self.load(fpath)
  File "/home/urbano/Projects/spdx/spec-parser/spec_parser/mdparsing.py", line 41, in load
    header = m.group(1)
             ^^^^^^^
AttributeError: 'NoneType' object has no attribute 'group'
```

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>



