### PR TITLE
rdf: Include @context in JSON-LD context

### DIFF
--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -139,5 +139,4 @@ def jsonld_context(g):
             short = s[len(URI_BASE):]
             if short:
                 terms[short] = 'spdx:' + short
-    return terms
-#     return {'@context': terms}
+    return {'@context': terms}


### PR DESCRIPTION
The context file is not valid without the @context entry