### PR TITLE
Ignore SpdxId

### DIFF
--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -23,6 +23,10 @@ from rdflib.tools.rdf2dot import (
 
 URI_BASE = 'https://rdf.spdx.org/v3/'
 
+IGNORED_PROPERTIES = [
+    "spdxId",
+]
+
 def gen_rdf(model, dir, cfg):
     p = Path(dir)
     p.mkdir(exist_ok=True)
@@ -69,6 +73,8 @@ def gen_rdf_ontology(model):
             p = model.classes[pns+parent]
             g.add((node, RDFS.subClassOf, URIRef(p.iri)))
         for p in c.properties:
+            if p in IGNORED_PROPERTIES:
+                continue
             bnode = BNode()
             g.add((node, SH.property, bnode))
             fqprop = c.properties[p]["fqname"]
@@ -114,6 +120,8 @@ def gen_rdf_ontology(model):
 
 
     for fqname, p in model.properties.items():
+        if p.name in IGNORED_PROPERTIES:
+            continue
         node = URIRef(p.iri)
         if p.summary:
             g.add((node, RDFS.comment, Literal(p.summary, lang='en')))

--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -60,6 +60,7 @@ def gen_rdf_ontology(model):
     for fqname, c in model.classes.items():
         node = URIRef(c.iri)
         g.add((node, RDF.type, OWL.Class))
+        g.add((node, RDF.type, SH.NodeShape))
         if c.summary:
             g.add((node, RDFS.comment, Literal(c.summary, lang='en')))
         parent = c.metadata.get("SubclassOf")
@@ -67,51 +68,49 @@ def gen_rdf_ontology(model):
             pns = "" if parent.startswith("/") else f"/{c.ns.name}/"
             p = model.classes[pns+parent]
             g.add((node, RDFS.subClassOf, URIRef(p.iri)))
-        if c.properties:
-            g.add((node, RDF.type, SH.NodeShape))
-            for p in c.properties:
-                bnode = BNode()
-                g.add((node, SH.property, bnode))
-                fqprop = c.properties[p]["fqname"]
-                prop = model.properties[fqprop]
-                g.add((bnode, SH.path, URIRef(prop.iri)))
-                prop_rng = prop.metadata["Range"]
-                if not ":" in prop_rng:
-                    typename = "" if prop_rng.startswith("/") else f"/{prop.ns.name}/"
-                    typename += prop_rng
-                else:
-                    typename = prop_rng
+        for p in c.properties:
+            bnode = BNode()
+            g.add((node, SH.property, bnode))
+            fqprop = c.properties[p]["fqname"]
+            prop = model.properties[fqprop]
+            g.add((bnode, SH.path, URIRef(prop.iri)))
+            prop_rng = prop.metadata["Range"]
+            if not ":" in prop_rng:
+                typename = "" if prop_rng.startswith("/") else f"/{prop.ns.name}/"
+                typename += prop_rng
+            else:
+                typename = prop_rng
 
-                if typename in model.classes:
-                    dt = model.classes[typename]
-                    g.add((bnode, SH["class"], URIRef(dt.iri)))
-                    g.add((bnode, SH.nodeKind, SH.BlankNodeOrIRI))
-                elif typename in model.vocabularies:
-                    dt = model.vocabularies[typename]
-                    g.add((bnode, SH["class"], URIRef(dt.iri)))
-                    g.add((bnode, SH.nodeKind, SH.IRI))
-                elif typename in model.datatypes:
-                    dt = model.datatypes[typename]
-                    if "pattern" in dt.format:
-                        g.add((bnode, SH.pattern, Literal(dt.format["pattern"])))
+            if typename in model.classes:
+                dt = model.classes[typename]
+                g.add((bnode, SH["class"], URIRef(dt.iri)))
+                g.add((bnode, SH.nodeKind, SH.BlankNodeOrIRI))
+            elif typename in model.vocabularies:
+                dt = model.vocabularies[typename]
+                g.add((bnode, SH["class"], URIRef(dt.iri)))
+                g.add((bnode, SH.nodeKind, SH.IRI))
+            elif typename in model.datatypes:
+                dt = model.datatypes[typename]
+                if "pattern" in dt.format:
+                    g.add((bnode, SH.pattern, Literal(dt.format["pattern"])))
 
-                    t = xsd_range(dt.metadata["SubclassOf"], prop.iri)
-                    if t:
-                        g.add((bnode, SH.datatype, t))
-                        g.add((bnode, SH.nodeKind, SH.Literal))
-                else:
-                    t = xsd_range(typename, prop.iri)
-                    if t:
-                        g.add((bnode, SH.datatype, t))
-                        g.add((bnode, SH.nodeKind, SH.Literal))
+                t = xsd_range(dt.metadata["SubclassOf"], prop.iri)
+                if t:
+                    g.add((bnode, SH.datatype, t))
+                    g.add((bnode, SH.nodeKind, SH.Literal))
+            else:
+                t = xsd_range(typename, prop.iri)
+                if t:
+                    g.add((bnode, SH.datatype, t))
+                    g.add((bnode, SH.nodeKind, SH.Literal))
 
 
-                mincount = c.properties[p]["minCount"]
-                if int(mincount) != 0:
-                    g.add((bnode, SH.minCount, Literal(int(mincount))))
-                maxcount = c.properties[p]["maxCount"]
-                if maxcount != '*':
-                    g.add((bnode, SH.maxCount, Literal(int(maxcount))))
+            mincount = c.properties[p]["minCount"]
+            if int(mincount) != 0:
+                g.add((bnode, SH.minCount, Literal(int(mincount))))
+            maxcount = c.properties[p]["maxCount"]
+            if maxcount != '*':
+                g.add((bnode, SH.maxCount, Literal(int(maxcount))))
 
 
     for fqname, p in model.properties.items():


### PR DESCRIPTION
Per discussion in the serialization meeting and with the closing of https://github.com/spdx/spdx-3-model/pull/673, the spec parser needs to explicitly ignore the `spdxId` property when generating output, since that property maps to the object ID (e.g. the triple subject) which should not be explicitly called out or the ontology is incorrect.