### PR TITLE
Skip spdxId in RDF generation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Jinja2==3.1.2
-jsonpickle==3.0.2
-rdflib==7.0.0
+Jinja2
+jsonpickle
+rdflib


### PR DESCRIPTION
Skips generating RDF for `Core/spdxId` usage and definition.

Also removes older specific versions from requirements

Fixes #103

