### PR TITLE
Adjust templates to make output Markdown tidy

### DIFF
--- a/spec_parser/templates/mkdocs/class.md.j2
+++ b/spec_parser/templates/mkdocs/class.md.j2
@@ -1,7 +1,6 @@
 {% extends "page.md.j2" %}
 
 {% block metadata %}
-
 | | |
 |---|---|
 | Name | {{metadata["name"]}} |
@@ -9,7 +8,6 @@
 {%if "SubclassOf" in metadata %}
 | SubclassOf | {{type_link(metadata["SubclassOf"])}} |
 {% endif %}
-
 {% endblock %}
 
 {% block extra %}
@@ -30,5 +28,4 @@
         {% endfor %}
     {% endfor %}
 {% endif %}
-
 {% endblock %}

--- a/spec_parser/templates/mkdocs/datatype.md.j2
+++ b/spec_parser/templates/mkdocs/datatype.md.j2
@@ -1,14 +1,12 @@
 {% extends "page.md.j2" %}
 
 {% block metadata %}
-
 | | |
 |---|---|
 | Name | {{metadata["name"]}} |
 {%if "SubclassOf" in metadata %}
 | SubclassOf | {{type_link(metadata["SubclassOf"])}} |
 {% endif %}
-
 {% endblock %}
 
 {% block extra %}
@@ -16,5 +14,4 @@
 ## Format
 
 - Pattern: `{{format["pattern"]}}`
-
 {% endblock %}

--- a/spec_parser/templates/mkdocs/individual.md.j2
+++ b/spec_parser/templates/mkdocs/individual.md.j2
@@ -1,13 +1,12 @@
 {% extends "page.md.j2" %}
 
 {% block metadata %}
-
 | | |
 |---|---|
 | Name | {{metadata["name"]}} |
 | Type | {{type_link(metadata["type"])}} |
 | IRI | `{{metadata["IRI"]}}` |
-
 {% endblock %}
 
-{% block extra %}{% endblock %}
+{% block extra %}
+{% endblock %}

--- a/spec_parser/templates/mkdocs/namespace.md.j2
+++ b/spec_parser/templates/mkdocs/namespace.md.j2
@@ -1,11 +1,10 @@
 {% extends "page.md.j2" %}
 
 {% block metadata %}
-
 | | |
 |---|---|
 | Name | {{metadata["name"]}} |
-
 {% endblock %}
 
-{% block extra %}{% endblock %}
+{% block extra %}
+{% endblock %}

--- a/spec_parser/templates/mkdocs/page.md.j2
+++ b/spec_parser/templates/mkdocs/page.md.j2
@@ -7,11 +7,9 @@
 
 {{summary}}
 
-
 ## Description
 
 {{description}}
-
 
 ## Metadata
 
@@ -19,7 +17,5 @@
 
 {% block metadata %}
 {% endblock %}
-
-
 {% block extra %}
 {% endblock %}

--- a/spec_parser/templates/mkdocs/property.md.j2
+++ b/spec_parser/templates/mkdocs/property.md.j2
@@ -1,13 +1,11 @@
 {% extends "page.md.j2" %}
 
 {% block metadata %}
-
 | | |
 |---|---|
 | Name | {{metadata["name"]}} |
 | Nature | {{metadata["Nature"]}} |
 | Range | {{type_link(metadata["Range"])}} |
-
 {% endblock %}
 
 {% block extra %}
@@ -19,5 +17,4 @@
 - {{type_link(name)}}
     {% endfor %}
 {% endif %}
-
 {% endblock %}

--- a/spec_parser/templates/mkdocs/vocabulary.md.j2
+++ b/spec_parser/templates/mkdocs/vocabulary.md.j2
@@ -1,11 +1,9 @@
 {% extends "page.md.j2" %}
 
 {% block metadata %}
-
 | | |
 |---|---|
 | Name | {{metadata["name"]}} |
-
 {% endblock %}
 
 {% block extra %}
@@ -15,5 +13,4 @@
 {% for name, val in entries | dictsort %}
 - {{name}}: {{val}}
 {% endfor %}
-
 {% endblock %}


### PR DESCRIPTION
Make generated Markdown files conform with markdownlint rules.

See the proposal in #120.

This will fix #120.