### PR TITLE
Mark abstract classes in RDF ontology

### DIFF
--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -50,6 +50,7 @@ def gen_rdf_ontology(model):
     g.bind("spdx", Namespace(URI_BASE))
     OMG_ANN = Namespace("https://www.omg.org/spec/Commons/AnnotationVocabulary/")
     g.bind("omg-ann", OMG_ANN)
+    AbstractClass = URIRef("http://spdx.invalid./AbstractClass")
 
     node = URIRef(URI_BASE)
     g.add((node, RDF.type, OWL.Ontology))
@@ -82,6 +83,8 @@ def gen_rdf_ontology(model):
             pns = "" if parent.startswith("/") else f"/{c.ns.name}/"
             p = model.classes[pns + parent]
             g.add((node, RDFS.subClassOf, URIRef(p.iri)))
+        if c.metadata["Instantiability"] == "Abstract":
+            g.add((node, RDF.type, AbstractClass))
         if c.properties:
             g.add((node, RDF.type, SH.NodeShape))
             for p in c.properties:


### PR DESCRIPTION
This is a simple implementation fixing the first part of https://github.com/spdx/spdx-3-model/issues/418

Abstract classes are marked in the generated ontology by adding that they have also the type `http://spdx.invalid./AbstractClass`. 

The URI was specifically chose to **not** be inside the usual SPDX RDF namespace and it should never resolve to anything.

Information for testing: the current model has twelve (!2) instances of Abstract classes.