### PR TITLE
Add IRI to individuals if not present

### DIFF
--- a/spec_parser/model.py
+++ b/spec_parser/model.py
@@ -304,6 +304,8 @@ class Individual:
 
         # processing
         self.iri = f"{self.ns.iri}/{self.name}"
+        if "IRI" not in self.metadata:
+            self.metadata["IRI"] = self.iri
 
 
 class Datatype:


### PR DESCRIPTION
If not specified, the `IRI` property should be the default.