### PR TITLE
Add profile conformance sections

### DIFF
--- a/spec_parser/model.py
+++ b/spec_parser/model.py
@@ -137,6 +137,12 @@ class Namespace:
         s = SingleListSection(sf.sections["Metadata"])
         self.metadata = s.kv
 
+        if "Profile conformance" in sf.sections:
+            s = ContentSection(sf.sections["Profile conformance"])
+            self.conformance = s.content
+        else:
+            self.conformance = None
+
         # checks
         assert self.name == self.metadata["name"], f"Namespace name {self.name} does not match metadata {self.metadata['name']}"
 

--- a/spec_parser/templates/mkdocs/class.md.j2
+++ b/spec_parser/templates/mkdocs/class.md.j2
@@ -14,21 +14,15 @@
 
 {% block extra %}
 
+{% if properties %}
 ## Properties
 
-{% if True %}
 | Property | Type | minCount | maxCount |
 |---|---|:---:|:---:|
     {% for name, kv in properties | dictsort %}
 | {{property_link(name)}} | {{type_link(kv["type"])}} | {{kv["minCount"]}} | {{kv["maxCount"]}} |
     {% endfor %}
-{% else %}
-    {% for name, subprops in properties | dictsort %}
-- {{name}}
-        {% for _key, _val in subprops | dictsort %}
-    - {{_key}}: {{_val}}
-        {% endfor %}
-    {% endfor %}
+
 {% endif %}
 
 {% endblock %}

--- a/spec_parser/templates/mkdocs/namespace.md.j2
+++ b/spec_parser/templates/mkdocs/namespace.md.j2
@@ -8,4 +8,13 @@
 
 {% endblock %}
 
-{% block extra %}{% endblock %}
+{% block extra %}
+
+{% if conformance %}
+## Profile conformance
+
+{{conformance}}
+
+{% endif %}
+
+{% endblock %}


### PR DESCRIPTION
This adds the "Profile conformance" sections in the generated mkdocs for profiles/namespaces.

Closes #126 

It also makes the "Properties" section in generated class files optional, i.e. not present when there are no properties.