### PR TITLE
Add global NamedIndividuals to JSON-LD context

### DIFF
--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -221,11 +221,12 @@ def jsonld_context(g):
     # Collect all named individuals
     for s in g.subjects(RDF.type, OWL.NamedIndividual):
         for _s, _p, o in g.triples((s, RDF.type, None)):
-            has_named_individuals.add(o)
+            if o != OWL.NamedIndividual:
+                has_named_individuals.add(o)
 
     for subject in sorted(g.subjects(unique=True)):
-        # Skip named individuals
-        if (subject, RDF.type, OWL.NamedIndividual) in g:
+        # Skip named individuals in vocabularies
+        if (subject, RDF.type, OWL.NamedIndividual) in g and any((subject, RDF.type, o) in g for o in has_named_individuals):
             continue
 
         try:


### PR DESCRIPTION
NamedIndividuals that are not part of a vocabulary (e.g. `NoneElement`) need mappings added to the JSON-LD context so that they are correctly expanded and compacted to their IRI