### PR TITLE
rdf: Set RDF.type for named individuals

### DIFF
--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -182,6 +182,7 @@ def gen_rdf_ontology(model):
         typename += typ
         dt = model.types[typename]
         g.add((node, RDFS.range, URIRef(dt.iri)))
+        g.add((node, RDF.type, URIRef(dt.iri)))
         custom_iri = i.metadata.get("IRI")
         if custom_iri:
             g.add((node, OWL.sameAs, URIRef(custom_iri)))


### PR DESCRIPTION
Non-vocabulary named individuals must have have their RDF.type set so that SHACL can validate that the node is of the correct type. Otherwise, it generates an error saying that e.g. NoAssertionElement cannot be assigned anywhere an Element is expected.