### PR TITLE
rdf: Use @vocab for global NamedIndividuals

### DIFF
--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -226,7 +226,7 @@ def jsonld_context(g):
                 elif (o, RDF.type, OWL.Class) in g:
                     return {
                         "@id": subject,
-                        "@type": "@id",
+                        "@type": "@vocab",
                     }
         elif (subject, RDF.type, OWL.DatatypeProperty) in g:
             for _, _, o in g.triples((subject, RDFS.range, None)):


### PR DESCRIPTION
Changes the JSON Schema so that properties that reference classes use @vocab instead of @id for their type. The difference is that @vocab will treat the value as a term and expand it using the current context (in this case, just the global context). The practical side effect of this is that @vocab will correctly examine if the value is a global named individual, whereas @id will not.

As an example:
```json
{
  "@context": {
    "class-prop": {
      "@id": "http://example.com/class-prop",
      "@type": "@vocab"
    },
    "named-individual": "http://example.com/named-individual"
  },
  "@id": "_:blank",
  "class-prop": "named-individual"
}
```
will expand the class-prop value to
"http://example.com/named-individual" where as:

```json
{
  "@context": {
    "class-prop": {
      "@id": "http://example.com/class-prop",
      "@type": "@id"
    },
    "named-individual": "http://example.com/named-individual"
  },
  "@id": "_:blank",
  "class-prop": "named-individual"
}
```

will not.