### PR TITLE
rdf: Set NodeKind for objects

### DIFF
--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -97,6 +97,12 @@ def gen_rdf_classes(model, g):
             g.add((node, RDFS.subClassOf, URIRef(p.iri)))
         if c.metadata["Instantiability"] == "Abstract":
             g.add((node, RDF.type, AbstractClass))
+
+        if "spdxId" in c.all_properties:
+            g.add((node, SH.nodeKind, SH.IRI))
+        else:
+            g.add((node, SH.nodeKind, SH.BlankNode))
+
         if c.properties:
             g.add((node, RDF.type, SH.NodeShape))
             for p in c.properties:


### PR DESCRIPTION
The SPDX Spec requires that objects derived from Element (e.g. those with an spdxId) _must_ have and IRI for their id. Any other object must _not_ have an IRI (since they are not to be referenced externally).

This was already semi-enforced in object properties by enforcing that property that referenced an object with an spdxId must be an IRI, but make this assertion even stronger by enforcing the node kind on the class definition itself. This prevents users from creating Elements with a blank node ID at all (which was previously allowed, but they wouldn't have been able to assign said node to any property value).