### PR TITLE
Make inheritance tree + bold metadata headings

### DIFF
--- a/spec_parser/templates/mkdocs/class.md.j2
+++ b/spec_parser/templates/mkdocs/class.md.j2
@@ -4,18 +4,19 @@
 
 | | |
 |---|---|
-| Name | {{metadata["name"]}} |
-| Instantiability | {{metadata["Instantiability"]}} |
-{%if "SubclassOf" in metadata %}
-| SubclassOf | {{type_link(metadata["SubclassOf"])}} |
+| **Name** | {{metadata["name"]}} |
+| **Instantiability** | {{metadata["Instantiability"]}} |
+{% if "SubclassOf" in metadata %}
+| **SubclassOf** | {{type_link(metadata["SubclassOf"])}} |
 {% endif %}
 
 
 {%if inheritance_stack %}
 ## Superclasses
 
-{% for super in inheritance_stack %}
-* {{type_link(super)}}
+{% set full_inheritance_stack = [fqname] + inheritance_stack %}
+{% for super in full_inheritance_stack | reverse %}
+{{ '&nbsp;' * ((loop.index-1)*4) }}└ {{type_link(super)}}<br />
 {% endfor %}
 {% endif %}
 

--- a/spec_parser/templates/mkdocs/class.md.j2
+++ b/spec_parser/templates/mkdocs/class.md.j2
@@ -14,7 +14,7 @@
 
 {% set full_inheritance_stack = [fqname] + inheritance_stack %}
 {% for super in full_inheritance_stack | reverse %}
-{{ '&nbsp;' * ((loop.index-1)*4) }}
+{{ '&nbsp;' * ((loop.index-1) * 6) }}
   {% if loop.last %}
 **{{type_link(super)}}**
   {% else %}

--- a/spec_parser/templates/mkdocs/class.md.j2
+++ b/spec_parser/templates/mkdocs/class.md.j2
@@ -10,15 +10,17 @@
 | **SubclassOf** | {{type_link(metadata["SubclassOf"])}} |
 {% endif %}
 
-
-{%if inheritance_stack %}
-## Superclasses
+## Inheritance
 
 {% set full_inheritance_stack = [fqname] + inheritance_stack %}
 {% for super in full_inheritance_stack | reverse %}
-{{ '&nbsp;' * ((loop.index-1)*4) }}└ {{type_link(super)}}<br />
+{{ '&nbsp;' * ((loop.index-1)*4) }}
+  {% if loop.last %}
+**{{type_link(super)}}**
+  {% else %}
+{{type_link(super)}}<br />
+  {% endif %}
 {% endfor %}
-{% endif %}
 
 {% endblock %}
 

--- a/spec_parser/templates/mkdocs/class.md.j2
+++ b/spec_parser/templates/mkdocs/class.md.j2
@@ -10,7 +10,7 @@
 | **SubclassOf** | {{type_link(metadata["SubclassOf"])}} |
 {% endif %}
 
-## Inheritance
+## Superclasses
 
 {% set full_inheritance_stack = [fqname] + inheritance_stack %}
 {% for super in full_inheritance_stack | reverse %}

--- a/spec_parser/templates/mkdocs/class.md.j2
+++ b/spec_parser/templates/mkdocs/class.md.j2
@@ -16,7 +16,7 @@
 {% for super in full_inheritance_stack | reverse %}
 {{ '&nbsp;' * ((loop.index-1) * 6) }}
   {% if loop.last %}
-**{{type_link(super)}}**
+{{type_link(super)}}
   {% else %}
 {{type_link(super)}}<br />
   {% endif %}

--- a/spec_parser/templates/mkdocs/datatype.md.j2
+++ b/spec_parser/templates/mkdocs/datatype.md.j2
@@ -4,9 +4,9 @@
 
 | | |
 |---|---|
-| Name | {{metadata["name"]}} |
+| **Name** | {{metadata["name"]}} |
 {%if "SubclassOf" in metadata %}
-| SubclassOf | {{type_link(metadata["SubclassOf"])}} |
+| **SubclassOf** | {{type_link(metadata["SubclassOf"])}} |
 {% endif %}
 
 {% endblock %}

--- a/spec_parser/templates/mkdocs/individual.md.j2
+++ b/spec_parser/templates/mkdocs/individual.md.j2
@@ -4,9 +4,9 @@
 
 | | |
 |---|---|
-| Name | {{metadata["name"]}} |
-| Type | {{type_link(metadata["type"])}} |
-| IRI | `{{metadata["IRI"]}}` |
+| **Name** | {{metadata["name"]}} |
+| **Type** | {{type_link(metadata["type"])}} |
+| **IRI** | `{{metadata["IRI"]}}` |
 
 {% endblock %}
 

--- a/spec_parser/templates/mkdocs/namespace.md.j2
+++ b/spec_parser/templates/mkdocs/namespace.md.j2
@@ -4,7 +4,7 @@
 
 | | |
 |---|---|
-| Name | {{metadata["name"]}} |
+| **Name** | {{metadata["name"]}} |
 
 {% endblock %}
 

--- a/spec_parser/templates/mkdocs/property.md.j2
+++ b/spec_parser/templates/mkdocs/property.md.j2
@@ -4,9 +4,9 @@
 
 | | |
 |---|---|
-| Name | {{metadata["name"]}} |
-| Nature | {{metadata["Nature"]}} |
-| Range | {{type_link(metadata["Range"])}} |
+| **Name** | {{metadata["name"]}} |
+| **Nature** | {{metadata["Nature"]}} |
+| **Range** | {{type_link(metadata["Range"])}} |
 
 {% endblock %}
 

--- a/spec_parser/templates/mkdocs/vocabulary.md.j2
+++ b/spec_parser/templates/mkdocs/vocabulary.md.j2
@@ -4,7 +4,7 @@
 
 | | |
 |---|---|
-| Name | {{metadata["name"]}} |
+| **Name** | {{metadata["name"]}} |
 
 {% endblock %}
 


### PR DESCRIPTION
- Add bold style for readability of metadata information
- Add tree formatting for readability of superclass information


Before:

- The table orientation is not obvious (does "CustomLicense" a table header?)
- The order of inheritance is not very obvious
<img width="400" src="https://github.com/user-attachments/assets/5c1f2f02-0e1a-4a63-94c1-0d4594a768c2">


After:

- Bold text on the left column of metadata table, make it clearer that it is the "header"
- Tree-like inheritance list with indents, make it clearer about the direction of inheritance
<img width="400" src="https://github.com/user-attachments/assets/adfc46fb-5171-4615-a573-dc4a0ef2de7c">

(See [live](https://bact.github.io/spdx-spec/v3.0.1/model/ExpandedLicensing/Classes/CustomLicense/))

--

Reference - the style is taken from programming language doc, like [Java doc](https://docs.oracle.com/javase/8/docs/api/):

<img width="270" src="https://github.com/user-attachments/assets/394d5d8a-b53b-482a-bb62-3de9e734aca0">
