### PR TITLE
Fix title capitalization issue by specify each file's title in mkdocs.yml file list

### DIFF
--- a/spec_parser/mkdocs.py
+++ b/spec_parser/mkdocs.py
@@ -61,7 +61,7 @@ def gen_mkdocs(model, outdir, cfg):
         if nameslist:
             ret.append(f"    - {heading}:")
             for n in sorted(nameslist):
-                ret.append(f"      - model/{nsname}/{heading}/{n}.md")
+                ret.append(f"      - '{n}': model/{nsname}/{heading}/{n}.md")
         return ret
 
     files = dict()
@@ -134,4 +134,3 @@ def type_link(name, model, showshort=False):
         return f"[{name}](../{dirname}/{name}.md)"
     else:
         return f"{name}"
-


### PR DESCRIPTION
MkDocs determines the title of a page in a [four step process](https://www.mkdocs.org/user-guide/writing-your-docs/#meta-data) - This PR use the first approach, defined the title in the `nav` config. The title is taken from the filename and respect the casing of the filename.

This will fix https://github.com/spdx/spdx-spec/issues/1062

A property with a single-word name should be displayed in their original casing.

Before:

<img title="Single word capitalized" src="https://github.com/user-attachments/assets/0654e538-9dd5-461c-b0f8-be29ffad2495" width="400" />

After:
<img title="Fixed" src="https://github.com/user-attachments/assets/ed301bea-3719-46c3-9b99-76a1ac0ac877" width="300" />