### PR TITLE
Add command-line options to select formats for generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ md_generated
 spdx-spec
 spec-v3-template
 tmp
+logs/
 
 # sphinx build folder #
 #######################
@@ -14,7 +15,6 @@ docs/_build
 
 # OS generated files #
 ######################
-*__pycache__
 *.DS_Store?
 *ehthumbs.db
 *Icon?
@@ -23,3 +23,10 @@ docs/_build
 # Virtual Env        #
 ######################
 venv
+.env
+
+# Python caches      #
+######################
+*__pycache__
+__pycache__/
+.mypy_cache

--- a/README.md
+++ b/README.md
@@ -5,24 +5,30 @@ or to generate stuff.
 
 ## Usage
 
-```shell
+```text
 python3 ./main.py  -h 
-usage: main.py [-h] [-d] [-f] [-n] [-q] [-v] [-V] input_dir [output_dir]
+usage: main.py [-h] [-f] [-n] [-q] [-d] [-v] [-V] [-gA] [-gM] [-gR] [-gT] [-gU] [-gJ] input_dir [output_dir]
 
 Generate documentation from an SPDX 3.0 model
 
 positional arguments:
-  input_dir       Directory containing the input specification files
-  output_dir      Directory to write the output files to
+  input_dir            Directory containing the input specification files
+  output_dir           Directory to write the output files to
 
 options:
-  -h, --help      show this help message and exit
-  -d, --debug     Print debug output
-  -f, --force     Overwrite existing generated files
-  -n, --nooutput  Do not generate anything, only check input
-  -q, --quiet     Print no output
-  -v, --verbose   Print verbose output
-  -V, --version   show program's version number and exit
+  -h, --help           show this help message and exit
+  -f, --force          Overwrite existing generated files
+  -n, --nooutput       Do not generate anything, only check input
+  -q, --quiet          Print no output
+  -d, --debug          Print debug output (most verbose)
+  -v, --verbose        Print verbose output
+  -V, --version        show program's version number and exit
+  -gA, --gen-all       Generate everything (Default)
+  -gM, --gen-mkdocs    Generate MkDocs-ready Markdown
+  -gR, --gen-rdf       Generate RDF
+  -gT, --gen-tex       Generate Tex
+  -gU, --gen-plantuml  Generate PlantUML
+  -gJ, --gen-jsondump  Generate JSON dump
 ```
 
 Note that not all flags are functional yet.

--- a/main.py
+++ b/main.py
@@ -2,12 +2,24 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+
 from runparams import RunParams
 from spec_parser import Model
 
 if __name__ == "__main__":
     cfg = RunParams()
 
+    if cfg.opt_quiet:
+        logging.basicConfig(level=logging.ERROR)
+    elif cfg.opt_debug:
+        logging.basicConfig(level=logging.DEBUG)
+    elif cfg.opt_verbose:
+        logging.basicConfig(level=logging.INFO)
+    else:
+        logging.basicConfig(level=logging.WARNING)
+
     m = Model(cfg.input_dir)
-    if not cfg.opt_nooutput:
-        m.gen_all(cfg.output_dir, cfg)
+
+    if not cfg.opt_nooutput and cfg.output_dir:
+        m.generate(cfg.output_dir, cfg)

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import warnings
 
 from runparams import RunParams
 from spec_parser import Model
@@ -12,12 +13,17 @@ if __name__ == "__main__":
 
     if cfg.opt_quiet:
         logging.basicConfig(level=logging.ERROR)
+        warnings.filterwarnings("ignore", module="rdflib")
     elif cfg.opt_debug:
         logging.basicConfig(level=logging.DEBUG)
+        warnings.filterwarnings("default", module="rdflib")
     elif cfg.opt_verbose:
         logging.basicConfig(level=logging.INFO)
+        warnings.filterwarnings("module", module="rdflib")
     else:
         logging.basicConfig(level=logging.WARNING)
+        warnings.filterwarnings("once", module="rdflib")
+        warnings.filterwarnings("ignore", category=UserWarning)
 
     m = Model(cfg.input_dir)
 

--- a/runparams.py
+++ b/runparams.py
@@ -62,6 +62,7 @@ class RunParams:
         for arg, format_str in options:
             if getattr(self.args, arg) or self.args.gen_all:
                 formats.append(format_str)
+        # if nothing is selected, select all
         if not formats:
             formats = [format_str for _, format_str in options]
         return formats

--- a/runparams.py
+++ b/runparams.py
@@ -50,6 +50,23 @@ class RunParams:
         return sys.modules["spec_parser"].__version__
 
     @property
+    def gen_formats(self):
+        formats = []
+        options = [
+            ("gen_mkdocs", "mkdocs"),
+            ("gen_rdf", "rdf"),
+            ("gen_tex", "tex"),
+            ("gen_plantuml", "plantuml"),
+            ("gen_jsondump", "jsondump")
+        ]
+        for arg, format_str in options:
+            if getattr(self.args, arg) or self.args.gen_all:
+                formats.append(format_str)
+        if not formats:
+            formats = [format_str for _, format_str in options]
+        return formats
+
+    @property
     def all_as_dict(self):
         return {
             k: getattr(self, k)
@@ -62,6 +79,7 @@ class RunParams:
                 "opt_quiet",
                 "opt_verbose",
                 "parser_version",
+                "gen_formats"
             )
         }
 
@@ -75,15 +93,21 @@ class RunParams:
         parser = argparse.ArgumentParser(description="Generate documentation from an SPDX 3.0 model")
         parser.add_argument("input_dir", help="Directory containing the input specification files")
         parser.add_argument("output_dir", nargs="?", help="Directory to write the output files to")
-        parser.add_argument("-d", "--debug", action="store_true", help="Print debug output")
         parser.add_argument("-f", "--force", action="store_true", help="Overwrite existing generated files")
         parser.add_argument("-n", "--nooutput", action="store_true", help="Do not generate anything, only check input")
         parser.add_argument("-q", "--quiet", action="store_true", help="Print no output")
+        parser.add_argument("-d", "--debug", action="store_true", help="Print debug output (most verbose)")
         parser.add_argument("-v", "--verbose", action="store_true", help="Print verbose output")
         parser.add_argument("-V", "--version", action="version", version=f"%(prog)s {RunParams.parser_version}")
+        parser.add_argument("-gA", "--gen-all", action="store_true", help="Generate everything (Default)")
+        parser.add_argument("-gM", "--gen-mkdocs", action="store_true", help="Generate MkDocs-ready Markdown")
+        parser.add_argument("-gR", "--gen-rdf", action="store_true", help="Generate RDF")
+        parser.add_argument("-gT", "--gen-tex", action="store_true", help="Generate Tex")
+        parser.add_argument("-gU", "--gen-plantuml", action="store_true", help="Generate PlantUML")
+        parser.add_argument("-gJ", "--gen-jsondump", action="store_true", help="Generate JSON dump")
         self.args = parser.parse_args(args)
 
         if self.opt_nooutput and self.output_dir:
             logging.warning(f"Ignoring output directory {self.output_dir} specified with --nooutput")
         if not self.opt_nooutput and not self.output_dir:
-            logging.critical("No output directory specified!")
+            logging.critical("The output_dir argument is required when the --nooutput option is not specified.")

--- a/spec_parser/jsondump.py
+++ b/spec_parser/jsondump.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 from pathlib import Path
 
 import jsonpickle
@@ -9,7 +10,11 @@ import jsonpickle
 
 def gen_jsondump(model, outdir, cfg):
     p = Path(outdir) / "jsondump"
-    p.mkdir()
+    if p.exists() and not cfg.opt_force:
+        logging.error(f"Destination for JSON dump: {p} already exists, will not overwrite")
+        return
+    p.mkdir(exist_ok=True)
 
     f = p / "model.json"
+
     f.write_text(jsonpickle.encode(model, indent=2, warn=True))

--- a/spec_parser/jsondump.py
+++ b/spec_parser/jsondump.py
@@ -17,5 +17,4 @@ def gen_jsondump(model, outdir, cfg):
     p.mkdir(exist_ok=True)
 
     f = p / "model.json"
-
     f.write_text(jsonpickle.encode(model, indent=2, warn=True))

--- a/spec_parser/jsondump.py
+++ b/spec_parser/jsondump.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import sys
 from pathlib import Path
 
 import jsonpickle
@@ -12,7 +13,7 @@ def gen_jsondump(model, outdir, cfg):
     p = Path(outdir) / "jsondump"
     if p.exists() and not cfg.opt_force:
         logging.error(f"Destination for JSON dump: {p} already exists, will not overwrite")
-        return
+        sys.exit(1)
     p.mkdir(exist_ok=True)
 
     f = p / "model.json"

--- a/spec_parser/mkdocs.py
+++ b/spec_parser/mkdocs.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import sys
 from pathlib import Path
 
 from jinja2 import Environment, PackageLoader, select_autoescape
@@ -26,7 +27,7 @@ def gen_mkdocs(model, outdir, cfg):
     p = op / "mkdocs"
     if p.exists() and not cfg.opt_force:
         logging.error(f"Destination for MkDocs: {p} already exists, will not overwrite")
-        return
+        sys.exit(1)
     p.mkdir(exist_ok=True)
 
     for ns in model.namespaces:

--- a/spec_parser/mkdocs.py
+++ b/spec_parser/mkdocs.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 from pathlib import Path
 
 from jinja2 import Environment, PackageLoader, select_autoescape
@@ -23,11 +24,14 @@ def gen_mkdocs(model, outdir, cfg):
 
     op = Path(outdir)
     p = op / "mkdocs"
-    p.mkdir()
+    if p.exists() and not cfg.opt_force:
+        logging.error(f"Destination for MkDocs: {p} already exists, will not overwrite")
+        return
+    p.mkdir(exist_ok=True)
 
     for ns in model.namespaces:
         d = p / ns.name
-        d.mkdir()
+        d.mkdir(exist_ok=True)
         f = d / f"{ns.name}.md"
 
         template = jinja.get_template("namespace.md.j2")

--- a/spec_parser/model.py
+++ b/spec_parser/model.py
@@ -162,7 +162,7 @@ class Model:
                             logging.warning(f"In class {c.fqname} property {p} has same {k} as the parent class")
                         c.all_properties[shortname][k] = v
 
-    def gen_all(self, outdir, cfg):
+    def generate(self, outdir, cfg):
         from .jsondump import gen_jsondump
         from .mkdocs import gen_mkdocs
         from .plantuml import gen_plantuml
@@ -175,11 +175,21 @@ class Model:
             return
         p.mkdir(parents=True)
 
-        gen_mkdocs(self, outdir, cfg)
-        gen_rdf(self, outdir, cfg)
-        gen_tex(self, outdir, cfg)
-        gen_plantuml(self, outdir, cfg)
-        gen_jsondump(self, outdir, cfg)
+        if "mkdocs" in cfg.gen_formats:
+            logging.info("Generating MkDocs ...")
+            gen_mkdocs(self, outdir, cfg)
+        if "rdf" in cfg.gen_formats:
+            logging.info("Generating RDF ...")
+            gen_rdf(self, outdir, cfg)
+        if "tex" in cfg.gen_formats:
+            logging.info("Generating Tex ...")
+            gen_tex(self, outdir, cfg)
+        if "plantuml" in cfg.gen_formats:
+            logging.info("Generating PlantUML ...")
+            gen_plantuml(self, outdir, cfg)
+        if "jsondump" in cfg.gen_formats:
+            logging.info("Generating JSON dump ...")
+            gen_jsondump(self, outdir, cfg)
 
 
 class Namespace:

--- a/spec_parser/model.py
+++ b/spec_parser/model.py
@@ -171,9 +171,9 @@ class Model:
 
         p = Path(outdir)
         if p.exists() and not cfg.opt_force:
-            logging.error(f"Destination for mkdocs {outdir} already exists, will not overwrite")
+            logging.error(f"Destination for model: {p} already exists, will not overwrite")
             return
-        p.mkdir(parents=True)
+        p.mkdir(exist_ok=True, parents=True)
 
         if "mkdocs" in cfg.gen_formats:
             logging.info("Generating MkDocs ...")

--- a/spec_parser/model.py
+++ b/spec_parser/model.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import sys
 from copy import deepcopy
 from pathlib import Path
 
@@ -31,7 +32,7 @@ class Model:
         self.toplevel = p = Path(indir)
         if not p.is_dir():
             logging.error(f"{indir}: not a directory")
-            return
+            sys.exit(1)
         if p.name != "model":
             logging.warning(f'{indir}: input not named "model"')
 
@@ -172,7 +173,7 @@ class Model:
         p = Path(outdir)
         if p.exists() and not cfg.opt_force:
             logging.error(f"Destination for model: {p} already exists, will not overwrite")
-            return
+            sys.exit(1)
         p.mkdir(exist_ok=True, parents=True)
 
         if "mkdocs" in cfg.gen_formats:

--- a/spec_parser/plantuml.py
+++ b/spec_parser/plantuml.py
@@ -2,11 +2,15 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 from pathlib import Path
 
 
 def gen_plantuml(model, outdir, cfg):
     p = Path(outdir) / "diagram"
+    if p.exists() and not cfg.opt_force:
+        logging.error(f"Destination for PlantUML: {p} already exists, will not overwrite")
+        return
     p.mkdir(exist_ok=True)
 
     f = p / "model.plantuml"

--- a/spec_parser/plantuml.py
+++ b/spec_parser/plantuml.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import sys
 from pathlib import Path
 
 
@@ -10,7 +11,7 @@ def gen_plantuml(model, outdir, cfg):
     p = Path(outdir) / "diagram"
     if p.exists() and not cfg.opt_force:
         logging.error(f"Destination for PlantUML: {p} already exists, will not overwrite")
-        return
+        sys.exit(1)
     p.mkdir(exist_ok=True)
 
     f = p / "model.plantuml"

--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -4,15 +4,10 @@
 
 import json
 import logging
+import sys
 from pathlib import Path
 
-from rdflib import (
-    BNode,
-    Graph,
-    Literal,
-    Namespace,
-    URIRef,
-)
+from rdflib import BNode, Graph, Literal, Namespace, URIRef
 from rdflib.collection import Collection
 from rdflib.namespace import DCTERMS, OWL, RDF, RDFS, SH, SKOS, XSD
 from rdflib.tools.rdf2dot import rdf2dot
@@ -24,7 +19,7 @@ def gen_rdf(model, outdir, cfg):
     p = Path(outdir) / "rdf"
     if p.exists() and not cfg.opt_force:
         logging.error(f"Destination for RDF: {p} already exists, will not overwrite")
-        return
+        sys.exit(1)
     p.mkdir(exist_ok=True)
 
     ret = gen_rdf_ontology(model)
@@ -40,7 +35,7 @@ def gen_rdf(model, outdir, cfg):
     p = Path(outdir) / "diagram"
     if p.exists() and not cfg.opt_force:
         logging.error(f"Destination for diagram: {p} already exists, will not overwrite")
-        return
+        sys.exit(1)
     p.mkdir(exist_ok=True)
     fn = p / "spdx-model.dot"
     with fn.open("w") as f:

--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -22,7 +22,10 @@ URI_BASE = "https://spdx.org/rdf/3.0.1/terms/"
 
 def gen_rdf(model, outdir, cfg):
     p = Path(outdir) / "rdf"
-    p.mkdir()
+    if p.exists() and not cfg.opt_force:
+        logging.error(f"Destination for RDF: {p} already exists, will not overwrite")
+        return
+    p.mkdir(exist_ok=True)
 
     ret = gen_rdf_ontology(model)
     for ext in ["hext", "json-ld", "longturtle", "n3", "nt", "pretty-xml", "trig", "ttl", "xml"]:
@@ -35,6 +38,9 @@ def gen_rdf(model, outdir, cfg):
         json.dump(ctx, f, sort_keys=True, indent=2)
 
     p = Path(outdir) / "diagram"
+    if p.exists() and not cfg.opt_force:
+        logging.error(f"Destination for diagram: {p} already exists, will not overwrite")
+        return
     p.mkdir(exist_ok=True)
     fn = p / "spdx-model.dot"
     with fn.open("w") as f:

--- a/spec_parser/tex.py
+++ b/spec_parser/tex.py
@@ -4,6 +4,7 @@
 
 import logging
 import re
+import sys
 from pathlib import Path
 
 from jinja2 import Environment, PackageLoader, select_autoescape
@@ -25,7 +26,7 @@ def gen_tex(model, outdir, cfg):
     p = op / "tex"
     if p.exists() and not cfg.opt_force:
         logging.error(f"Destination for Tex: {p} already exists, will not overwrite")
-        return
+        sys.exit(1)
     p.mkdir(exist_ok=True)
 
     for ns in model.namespaces:

--- a/spec_parser/tex.py
+++ b/spec_parser/tex.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import re
 from pathlib import Path
 
@@ -22,11 +23,14 @@ def gen_tex(model, outdir, cfg):
 
     op = Path(outdir)
     p = op / "tex"
-    p.mkdir()
+    if p.exists() and not cfg.opt_force:
+        logging.error(f"Destination for Tex: {p} already exists, will not overwrite")
+        return
+    p.mkdir(exist_ok=True)
 
     for ns in model.namespaces:
         d = p / ns.name
-        d.mkdir()
+        d.mkdir(exist_ok=True)
         f = d / f"{ns.name}.tex"
 
         template = jinja.get_template("namespace.tex.j2")


### PR DESCRIPTION
From a suggestion in https://github.com/spdx/spdx-spec/issues/1112#issuecomment-2334799740,
these `-g*` command-line options are added:

```text
  -gA, --gen-all       Generate everything (Default)
  -gM, --gen-mkdocs    Generate MkDocs-ready Markdown
  -gR, --gen-rdf       Generate RDF
  -gT, --gen-tex       Generate Tex
  -gU, --gen-plantuml  Generate PlantUML
  -gJ, --gen-jsondump  Generate JSON dump
```

- If `--gen-all` is specified, it will override the rest of `-g` options
  - `--gen-mkdocs --gen-rdf` - generates only MkDocs and RDF
  - `--gen-tex` - generates only Tex
  - `--gen-mkdocs --gen-all` - generates everything 
- If none of the generation options is specified, the script will generate everything (effectively the same as `--gen-all`)
- Also implement `--quiet`, `--debug`, `--verbose` log level options (partially include rdflib warnings) and `--force`
  - UserWarning about "Assertions on rdflib.term.BNode other than RDF.first and RDF.rest are ignored" can now be suppressed by `--quiet`; Still printed with `--debug` and `--verbose`