### PR TITLE
Implement --quiet, --debug, --verbose options 

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,28 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+import warnings
+
 from runparams import RunParams
 from spec_parser import Model
 
 if __name__ == "__main__":
     cfg = RunParams()
+
+    if cfg.opt_quiet:
+        logging.basicConfig(level=logging.ERROR)
+        warnings.filterwarnings("ignore", module="rdflib")
+    elif cfg.opt_debug:
+        logging.basicConfig(level=logging.DEBUG)
+        warnings.filterwarnings("default", module="rdflib")
+    elif cfg.opt_verbose:
+        logging.basicConfig(level=logging.INFO)
+        warnings.filterwarnings("module", module="rdflib")
+    else:
+        logging.basicConfig(level=logging.WARNING)
+        warnings.filterwarnings("once", module="rdflib")
+        warnings.filterwarnings("ignore", category=UserWarning)
 
     m = Model(cfg.input_dir)
     if not cfg.opt_nooutput:

--- a/main.py
+++ b/main.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     else:
         logging.basicConfig(level=logging.WARNING)
         warnings.filterwarnings("once", module="rdflib")
-        warnings.filterwarnings("ignore", category=UserWarning)
+        warnings.filterwarnings("ignore", message=r".*Assertions on rdflib\.term\.BNode.*RDF\.first and RDF\.rest.*")
 
     m = Model(cfg.input_dir)
     if not cfg.opt_nooutput:


### PR DESCRIPTION
- Implement --quiet, --debug, --verbose options to control verbosity.
- RDFLib warnings can be suppressed entirely with --quiet
- By default (no arguments given), RDFLib warning about *"Assertions on rdflib.term.BNode ... other than RDF.first and RDF.rest"* in #142 will also be suppressed
  - If this is not preferred, Line 26 can be removed