### PR TITLE
Add creationInfo to named individuals

### DIFF
--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -213,7 +213,7 @@ def gen_rdf_individuals(model, g):
         created = URIRef(URI_BASE + "Core/created")
         createdBy = URIRef(URI_BASE + "Core/createdBy")
         spdxId = URIRef(URI_BASE + "Core/spdxId")
-        SpdxOrganization = URIRef("https://spdx.org/")
+        SpdxOrganization = URIRef(URI_BASE + "Core/SpdxOrganization")
         specVersion = URIRef(URI_BASE + "Core/specVersion")
 
     # Define an instance of CreationInfo as a blank node

--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -216,7 +216,9 @@ def gen_rdf_individuals(model, g):
         specVersion = URIRef(URI_BASE + "Core/specVersion")
 
     # Define an instance of CreationInfo as a blank node
-    creation_info = BNode("_CreationInfo")
+    version = SPDX_VERSION.replace(".", "_")  # 3.0.1 -> 3_0_1
+    creation_info_name = f"_V{version}_CreationInfo"  # unique across versions
+    creation_info = BNode(creation_info_name)
     g.add((creation_info, RDF.type, SPDX.CreationInfo))
     g.add((creation_info, SPDX.created, Literal(CREATION_DATETIME, datatype=XSD.dateTimeStamp)))
     g.add((creation_info, SPDX.createdBy, SPDX.SpdxOrganization))

--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -17,8 +17,9 @@ from rdflib.collection import Collection
 from rdflib.namespace import DCTERMS, OWL, RDF, RDFS, SH, SKOS, XSD
 from rdflib.tools.rdf2dot import rdf2dot
 
-URI_BASE = "https://spdx.org/rdf/3.0.1/terms/"
 CREATION_DATETIME = "2024-09-13T00:00:00Z"
+SPDX_VERSION = "3.0.1"
+URI_BASE = f"https://spdx.org/rdf/{SPDX_VERSION}/terms/"
 
 
 def gen_rdf(model, outdir, cfg):
@@ -205,32 +206,22 @@ def gen_rdf_vocabularies(model, g):
 
 def gen_rdf_individuals(model, g):
     class SPDX:
-        """SPDX terms
-        """
+        """SPDX terms"""
+
         CreationInfo = URIRef(URI_BASE + "Core/CreationInfo")
         creationInfo = URIRef(URI_BASE + "Core/creationInfo")
         created = URIRef(URI_BASE + "Core/created")
         createdBy = URIRef(URI_BASE + "Core/createdBy")
-        Organization = URIRef(URI_BASE + "Core/Organization")
-        specVersion = URIRef(URI_BASE + "Core/specVersion")
         spdxId = URIRef(URI_BASE + "Core/spdxId")
-
-    # Define _SpdxOrganization named individual
-    spdx_org = URIRef(URI_BASE + "Core/_SpdxOrganization")
-    g.add((spdx_org, RDF.type, OWL.NamedIndividual))
-    g.add((spdx_org, RDF.type, SPDX.Organization))
-    g.add((spdx_org, SPDX.spdxId, URIRef("https://spdx.org/")))
-    g.add((spdx_org, RDFS.comment, Literal("SPDX Project", lang="en")))
+        SpdxOrganization = URIRef("https://spdx.org/")
+        specVersion = URIRef(URI_BASE + "Core/specVersion")
 
     # Define an instance of CreationInfo as a blank node
     creation_info = BNode("_CreationInfo")
     g.add((creation_info, RDF.type, SPDX.CreationInfo))
     g.add((creation_info, SPDX.created, Literal(CREATION_DATETIME, datatype=XSD.dateTimeStamp)))
-    g.add((creation_info, SPDX.createdBy, spdx_org))
-    g.add((creation_info, SPDX.specVersion, Literal("3.0.1", datatype=XSD.string)))
-
-    # Add creationInfo to _SpdxOrganization
-    g.add((spdx_org, SPDX.creationInfo, creation_info))
+    g.add((creation_info, SPDX.createdBy, SPDX.SpdxOrganization))
+    g.add((creation_info, SPDX.specVersion, Literal(SPDX_VERSION, datatype=XSD.string)))
 
     # Add all individuals
     for i in model.individuals.values():

--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -212,7 +212,6 @@ def gen_rdf_individuals(model, g):
         creationInfo = URIRef(URI_BASE + "Core/creationInfo")
         created = URIRef(URI_BASE + "Core/created")
         createdBy = URIRef(URI_BASE + "Core/createdBy")
-        spdxId = URIRef(URI_BASE + "Core/spdxId")
         SpdxOrganization = URIRef(URI_BASE + "Core/SpdxOrganization")
         specVersion = URIRef(URI_BASE + "Core/specVersion")
 

--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -219,7 +219,7 @@ def gen_rdf_individuals(model, g):
     spdx_org = URIRef(URI_BASE + "Core/_SpdxOrganization")
     g.add((spdx_org, RDF.type, OWL.NamedIndividual))
     g.add((spdx_org, RDF.type, SPDX.Organization))
-    g.add((spdx_org, SPDX.spdxId, URIRef("https://spdx.dev/")))
+    g.add((spdx_org, SPDX.spdxId, URIRef("https://spdx.org/")))
     g.add((spdx_org, RDFS.comment, Literal("SPDX Project", lang="en")))
 
     # Define an instance of CreationInfo as a blank node


### PR DESCRIPTION
Add `creationInfo` to named individuals, so it will pass the validation.

To fix #153

Based on https://github.com/spdx/spec-parser/issues/153#issuecomment-2344300010 and rely on `SpdxOrganization` individual to be created from https://github.com/spdx/spdx-3-model/pull/880

--

Generated spdx-model.ttl:

```
@prefix ns1: <https://spdx.org/rdf/3.0.1/terms/Core/> .
@prefix ns7: <https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/> 

ns1:_SpdxOrganization a owl:NamedIndividual,
        ns1:Organization ;
    rdfs:comment "SPDX Project"@en ;
    ns1:creationInfo _:_CreationInfo ;
    ns1:spdxId <https://spdx.org/> .

ns1:NoAssertionElement a owl:NamedIndividual,
        ns1:Element ;
    rdfs:comment """An Individual Value for Element representing a set of Elements of unknown
identify or cardinality (number)."""@en ;
    ns1:creationInfo _:_CreationInfo .

ns1:NoneElement a owl:NamedIndividual,
        ns1:Element ;
    rdfs:comment """An Individual Value for Element representing a set of Elements with
cardinality (number/count) of zero."""@en ;
    ns1:creationInfo _:_CreationInfo .

ns7:NoAssertionLicense a owl:NamedIndividual,
        ns7:IndividualLicensingInfo ;
    rdfs:comment """An Individual Value for License when no assertion can be made about its actual
value."""@en ;
    owl:sameAs <https://spdx.org/rdf/3.0.1/terms/Licensing/NoAssertion> ;
    ns1:creationInfo _:_CreationInfo .

ns7:NoneLicense a owl:NamedIndividual,
        ns7:IndividualLicensingInfo ;
    rdfs:comment """An Individual Value for License where the SPDX data creator determines that no
license is present."""@en ;
    owl:sameAs <https://spdx.org/rdf/3.0.1/terms/Licensing/None> ;
    ns1:creationInfo _:_CreationInfo .

_:_CreationInfo a ns1:CreationInfo ;
    ns1:created "2024-09-13T00:00:00Z"^^xsd:dateTimeStamp ;
    ns1:createdBy ns1:_SpdxOrganization ;
    ns1:specVersion "3.0.1"^^xsd:string .
```