### PR TITLE
Split ontology and shapes graph

### DIFF
--- a/spec_parser/mkdocs.py
+++ b/spec_parser/mkdocs.py
@@ -18,16 +18,18 @@ def gen_mkdocs(model, outdir, cfg):
     jinja.globals["class_link"] = class_link
     jinja.globals["property_link"] = property_link
     jinja.globals["ext_property_link"] = ext_property_link
-    jinja.globals["type_link"] = lambda x, showshort=False: type_link(x, model, showshort)
+    jinja.globals["type_link"] = lambda x, showshort=False: type_link(
+        x, model, showshort
+    )
     jinja.globals["not_none"] = lambda x: str(x) if x is not None else ""
 
     op = Path(outdir)
     p = op / "mkdocs"
-    p.mkdir()
+    p.mkdir(exist_ok=True)
 
     for ns in model.namespaces:
         d = p / ns.name
-        d.mkdir()
+        d.mkdir(exist_ok=True)
         f = d / f"{ns.name}.md"
 
         template = jinja.get_template("namespace.md.j2")

--- a/spec_parser/model.py
+++ b/spec_parser/model.py
@@ -173,7 +173,7 @@ class Model:
         if p.exists() and not cfg.opt_force:
             logging.error(f"Destination for mkdocs {outdir} already exists, will not overwrite")
             return
-        p.mkdir(parents=True)
+        p.mkdir(parents=True, exist_ok=True)
 
         gen_mkdocs(self, outdir, cfg)
         gen_rdf(self, outdir, cfg)

--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -22,23 +22,35 @@ URI_BASE = "https://spdx.org/rdf/3.0.1/terms/"
 
 def gen_rdf(model, outdir, cfg):
     p = Path(outdir) / "rdf"
-    p.mkdir()
+    p.mkdir(exist_ok=True)
 
-    ret = gen_rdf_ontology(model)
-    for ext in ["hext", "json-ld", "longturtle", "n3", "nt", "pretty-xml", "trig", "ttl", "xml"]:
-        f = p / ("spdx-model." + ext)
-        ret.serialize(f, format=ext, encoding="utf-8")
+    ont, shapes = gen_rdf_ontology(model)
+    for ext in [
+        "hext",
+        "json-ld",
+        "longturtle",
+        "n3",
+        "nt",
+        "pretty-xml",
+        "trig",
+        "ttl",
+        "xml",
+    ]:
+        shapes.serialize(p / ("spdx-shapes." + ext), format=ext, encoding="utf-8")
+        ont.serialize(p / ("spdx-ontology." + ext), format=ext, encoding="utf-8")
 
-    ctx = jsonld_context(ret)
+    ctx = jsonld_context(ont, shapes)
     fn = p / "spdx-context.jsonld"
     with fn.open("w") as f:
         json.dump(ctx, f, sort_keys=True, indent=2)
 
     p = Path(outdir) / "diagram"
     p.mkdir(exist_ok=True)
-    fn = p / "spdx-model.dot"
-    with fn.open("w") as f:
-        rdf2dot(ret, f)
+    with (p / "spdx-shapes.dot").open("w") as f:
+        rdf2dot(shapes, f)
+
+    with (p / "spdx-ontology.dot").open("w") as f:
+        rdf2dot(ont, f)
 
 
 def xsd_range(rng, propname):
@@ -50,73 +62,106 @@ def xsd_range(rng, propname):
 
 
 def gen_rdf_ontology(model):
-    g = Graph()
-    g.bind("spdx", Namespace(URI_BASE))
+    ont = Graph()
+    shapes = Graph()
+
+    ont.bind("spdx", Namespace(URI_BASE))
+    shapes.bind("spdx", Namespace(URI_BASE))
+
     OMG_ANN = Namespace("https://www.omg.org/spec/Commons/AnnotationVocabulary/")
-    g.bind("omg-ann", OMG_ANN)
+    ont.bind("omg-ann", OMG_ANN)
+    shapes.bind("omg-ann", OMG_ANN)
 
-    node = URIRef(URI_BASE)
-    g.add((node, RDF.type, OWL.Ontology))
-    g.add((node, OWL.versionIRI, node))
-    g.add((node, RDFS.label, Literal("System Package Data Exchange (SPDX) Ontology", lang="en")))
-    g.add(
-        (
-            node,
-            DCTERMS.abstract,
-            Literal(
-                "This ontology defines the terms and relationships used in the SPDX specification to describe system packages",
-                lang="en",
+    def add_base(g):
+        node = URIRef(URI_BASE)
+        g.add((node, RDF.type, OWL.Ontology))
+        g.add((node, OWL.versionIRI, node))
+        g.add(
+            (
+                node,
+                RDFS.label,
+                Literal("System Package Data Exchange (SPDX) Ontology", lang="en"),
+            )
+        )
+        g.add(
+            (
+                node,
+                DCTERMS.abstract,
+                Literal(
+                    "This ontology defines the terms and relationships used in the SPDX specification to describe system packages",
+                    lang="en",
+                ),
             ),
-        ),
-    )
-    g.add((node, DCTERMS.created, Literal("2024-04-05", datatype=XSD.date)))
-    g.add((node, DCTERMS.creator, Literal("SPDX Project", lang="en")))
-    g.add((node, DCTERMS.license, URIRef("https://spdx.org/licenses/Community-Spec-1.0.html")))
-    g.add((node, DCTERMS.references, URIRef("https://spdx.dev/specifications/")))
-    g.add((node, DCTERMS.title, Literal("System Package Data Exchange (SPDX) Ontology", lang="en")))
-    g.add((node, OMG_ANN.copyright, Literal("Copyright (C) 2024 SPDX Project", lang="en")))
+        )
+        g.add((node, DCTERMS.created, Literal("2024-04-05", datatype=XSD.date)))
+        g.add((node, DCTERMS.creator, Literal("SPDX Project", lang="en")))
+        g.add(
+            (
+                node,
+                DCTERMS.license,
+                URIRef("https://spdx.org/licenses/Community-Spec-1.0.html"),
+            )
+        )
+        g.add((node, DCTERMS.references, URIRef("https://spdx.dev/specifications/")))
+        g.add(
+            (
+                node,
+                DCTERMS.title,
+                Literal("System Package Data Exchange (SPDX) Ontology", lang="en"),
+            )
+        )
+        g.add(
+            (
+                node,
+                OMG_ANN.copyright,
+                Literal("Copyright (C) 2024 SPDX Project", lang="en"),
+            )
+        )
 
-    gen_rdf_classes(model, g)
-    gen_rdf_properties(model, g)
+    add_base(ont)
+    add_base(shapes)
+
+    gen_rdf_classes(model, ont, shapes)
+    gen_rdf_properties(model, ont, shapes)
     #     gen_rdf_datatypes(model, g)
-    gen_rdf_vocabularies(model, g)
-    gen_rdf_individuals(model, g)
+    gen_rdf_vocabularies(model, ont, shapes)
+    gen_rdf_individuals(model, ont, shapes)
 
-    return g
+    return ont, shapes
 
 
-def gen_rdf_classes(model, g):
+def gen_rdf_classes(model, ont, shapes):
     AbstractClass = URIRef("http://spdx.invalid./AbstractClass")
-    g.add((AbstractClass, RDF.type, OWL.Class))
+    ont.add((AbstractClass, RDF.type, OWL.Class))
 
     for c in model.classes.values():
         node = URIRef(c.iri)
-        g.add((node, RDF.type, OWL.Class))
+        ont.add((node, RDF.type, OWL.Class))
         if c.summary:
-            g.add((node, RDFS.comment, Literal(c.summary, lang="en")))
+            ont.add((node, RDFS.comment, Literal(c.summary, lang="en")))
         parent = c.metadata.get("SubclassOf")
         if parent:
             pns = "" if parent.startswith("/") else f"/{c.ns.name}/"
             p = model.classes[pns + parent]
-            g.add((node, RDFS.subClassOf, URIRef(p.iri)))
+            ont.add((node, RDFS.subClassOf, URIRef(p.iri)))
         if c.metadata["Instantiability"] == "Abstract":
-            g.add((node, RDF.type, AbstractClass))
+            ont.add((node, RDF.type, AbstractClass))
 
         if "spdxId" in c.all_properties:
-            g.add((node, SH.nodeKind, SH.IRI))
+            shapes.add((node, SH.nodeKind, SH.IRI))
         else:
-            g.add((node, SH.nodeKind, SH.BlankNode))
+            shapes.add((node, SH.nodeKind, SH.BlankNode))
 
         if c.properties:
-            g.add((node, RDF.type, SH.NodeShape))
+            shapes.add((node, RDF.type, SH.NodeShape))
             for p in c.properties:
                 fqprop = c.properties[p]["fqname"]
                 if fqprop == "/Core/spdxId":
                     continue
                 bnode = BNode()
-                g.add((node, SH.property, bnode))
+                shapes.add((node, SH.property, bnode))
                 prop = model.properties[fqprop]
-                g.add((bnode, SH.path, URIRef(prop.iri)))
+                shapes.add((bnode, SH.path, URIRef(prop.iri)))
                 prop_rng = prop.metadata["Range"]
                 if ":" not in prop_rng:
                     typename = "" if prop_rng.startswith("/") else f"/{prop.ns.name}/"
@@ -125,105 +170,105 @@ def gen_rdf_classes(model, g):
                     typename = prop_rng
                 if typename in model.classes:
                     dt = model.classes[typename]
-                    g.add((bnode, SH["class"], URIRef(dt.iri)))
+                    shapes.add((bnode, SH["class"], URIRef(dt.iri)))
                     if "spdxId" in dt.all_properties:
-                        g.add((bnode, SH.nodeKind, SH.IRI))
+                        shapes.add((bnode, SH.nodeKind, SH.IRI))
                     else:
-                        g.add((bnode, SH.nodeKind, SH.BlankNodeOrIRI))
+                        shapes.add((bnode, SH.nodeKind, SH.BlankNodeOrIRI))
                 elif typename in model.vocabularies:
                     dt = model.vocabularies[typename]
-                    g.add((bnode, SH["class"], URIRef(dt.iri)))
-                    g.add((bnode, SH.nodeKind, SH.IRI))
-                    lst = Collection(g, None)
+                    shapes.add((bnode, SH["class"], URIRef(dt.iri)))
+                    shapes.add((bnode, SH.nodeKind, SH.IRI))
+                    lst = Collection(shapes, None)
                     for e in dt.entries:
                         lst.append(URIRef(dt.iri + "/" + e))
-                    g.add((bnode, SH["in"], lst.uri))
+                    shapes.add((bnode, SH["in"], lst.uri))
                 elif typename in model.datatypes:
                     dt = model.datatypes[typename]
                     if "pattern" in dt.format:
-                        g.add((bnode, SH.pattern, Literal(dt.format["pattern"])))
+                        shapes.add((bnode, SH.pattern, Literal(dt.format["pattern"])))
                     t = xsd_range(dt.metadata["SubclassOf"], prop.iri)
                     if t:
-                        g.add((bnode, SH.datatype, t))
-                        g.add((bnode, SH.nodeKind, SH.Literal))
+                        shapes.add((bnode, SH.datatype, t))
+                        shapes.add((bnode, SH.nodeKind, SH.Literal))
                 else:
                     t = xsd_range(typename, prop.iri)
                     if t:
-                        g.add((bnode, SH.datatype, t))
-                        g.add((bnode, SH.nodeKind, SH.Literal))
+                        shapes.add((bnode, SH.datatype, t))
+                        shapes.add((bnode, SH.nodeKind, SH.Literal))
                 mincount = c.properties[p]["minCount"]
                 if int(mincount) != 0:
-                    g.add((bnode, SH.minCount, Literal(int(mincount))))
+                    shapes.add((bnode, SH.minCount, Literal(int(mincount))))
                 maxcount = c.properties[p]["maxCount"]
                 if maxcount != "*":
-                    g.add((bnode, SH.maxCount, Literal(int(maxcount))))
+                    shapes.add((bnode, SH.maxCount, Literal(int(maxcount))))
 
 
-def gen_rdf_properties(model, g):
+def gen_rdf_properties(model, ont, shapes):
     for fqname, p in model.properties.items():
         if fqname == "/Core/spdxId":
             continue
         node = URIRef(p.iri)
         if p.summary:
-            g.add((node, RDFS.comment, Literal(p.summary, lang="en")))
+            ont.add((node, RDFS.comment, Literal(p.summary, lang="en")))
         if p.metadata["Nature"] == "ObjectProperty":
-            g.add((node, RDF.type, OWL.ObjectProperty))
-        # to add: g.add((node, RDFS.domain, xxx))
+            ont.add((node, RDF.type, OWL.ObjectProperty))
+        # to add: ont.add((node, RDFS.domain, xxx))
         elif p.metadata["Nature"] == "DataProperty":
-            g.add((node, RDF.type, OWL.DatatypeProperty))
+            ont.add((node, RDF.type, OWL.DatatypeProperty))
         rng = p.metadata["Range"]
         if ":" in rng:
             t = xsd_range(rng, p.name)
             if t:
-                g.add((node, RDFS.range, t))
+                ont.add((node, RDFS.range, t))
         else:
             typename = "" if rng.startswith("/") else f"/{p.ns.name}/"
             typename += rng
             if typename in model.datatypes:
                 t = xsd_range(model.datatypes[typename].metadata["SubclassOf"], p.name)
                 if t:
-                    g.add((node, RDFS.range, t))
+                    ont.add((node, RDFS.range, t))
             else:
                 dt = model.types[typename]
-                g.add((node, RDFS.range, URIRef(dt.iri)))
+                ont.add((node, RDFS.range, URIRef(dt.iri)))
 
 
-def gen_rdf_vocabularies(model, g):
+def gen_rdf_vocabularies(model, ont, shapes):
     for v in model.vocabularies.values():
         node = URIRef(v.iri)
-        g.add((node, RDF.type, OWL.Class))
+        ont.add((node, RDF.type, OWL.Class))
         if v.summary:
-            g.add((node, RDFS.comment, Literal(v.summary, lang="en")))
+            ont.add((node, RDFS.comment, Literal(v.summary, lang="en")))
         for e, d in v.entries.items():
             enode = URIRef(v.iri + "/" + e)
-            g.add((enode, RDF.type, OWL.NamedIndividual))
-            g.add((enode, RDF.type, node))
-            g.add((enode, RDFS.label, Literal(e)))
-            g.add((enode, RDFS.comment, Literal(d, lang="en")))
+            ont.add((enode, RDF.type, OWL.NamedIndividual))
+            ont.add((enode, RDF.type, node))
+            ont.add((enode, RDFS.label, Literal(e)))
+            ont.add((enode, RDFS.comment, Literal(d, lang="en")))
 
 
-def gen_rdf_individuals(model, g):
+def gen_rdf_individuals(model, ont, shapes):
     for i in model.individuals.values():
         node = URIRef(i.iri)
-        g.add((node, RDF.type, OWL.NamedIndividual))
+        ont.add((node, RDF.type, OWL.NamedIndividual))
         if i.summary:
-            g.add((node, RDFS.comment, Literal(i.summary, lang="en")))
+            ont.add((node, RDFS.comment, Literal(i.summary, lang="en")))
         typ = i.metadata["type"]
         typename = "" if typ.startswith("/") else f"/{i.ns.name}/"
         typename += typ
         dt = model.types[typename]
-        g.add((node, RDF.type, URIRef(dt.iri)))
+        ont.add((node, RDF.type, URIRef(dt.iri)))
         custom_iri = i.metadata.get("IRI")
         if custom_iri and custom_iri != i.iri:
-            g.add((node, OWL.sameAs, URIRef(custom_iri)))
+            ont.add((node, OWL.sameAs, URIRef(custom_iri)))
 
 
-def jsonld_context(g):
+def jsonld_context(ont, shapes):
     terms = dict()
 
     def get_subject_term(subject):
-        if (subject, RDF.type, OWL.ObjectProperty) in g:
-            for _, _, o in g.triples((subject, RDFS.range, None)):
+        if (subject, RDF.type, OWL.ObjectProperty) in ont:
+            for _, _, o in ont.triples((subject, RDFS.range, None)):
                 if o in vocab_classes:
                     return {
                         "@id": subject,
@@ -232,13 +277,13 @@ def jsonld_context(g):
                             "@vocab": o + "/",
                         },
                     }
-                elif (o, RDF.type, OWL.Class) in g:
+                elif (o, RDF.type, OWL.Class) in ont:
                     return {
                         "@id": subject,
                         "@type": "@vocab",
                     }
-        elif (subject, RDF.type, OWL.DatatypeProperty) in g:
-            for _, _, o in g.triples((subject, RDFS.range, None)):
+        elif (subject, RDF.type, OWL.DatatypeProperty) in ont:
+            for _, _, o in ont.triples((subject, RDFS.range, None)):
                 return {
                     "@id": subject,
                     "@type": o,
@@ -248,18 +293,22 @@ def jsonld_context(g):
 
     vocab_named_individuals = set()
     vocab_classes = set()
-    for lst in g.objects(None, SH["in"]):
-        c = Collection(g, lst)
+    for lst in shapes.objects(None, SH["in"]):
+        c = Collection(shapes, lst)
         for e in c:
             vocab_named_individuals.add(e)
-            for typ in g.objects(e, RDF.type):
+            for typ in ont.objects(e, RDF.type):
                 if typ == OWL.NamedIndividual:
                     continue
                 vocab_classes.add(typ)
 
-    for subject in sorted(g.subjects(unique=True)):
+    for subject in sorted(ont.subjects(unique=True)):
         # Skip named individuals in vocabularies
-        if (subject, RDF.type, OWL.NamedIndividual) in g and subject in vocab_named_individuals:
+        if (
+            subject,
+            RDF.type,
+            OWL.NamedIndividual,
+        ) in ont and subject in vocab_named_individuals:
             continue
 
         try:
@@ -274,7 +323,9 @@ def jsonld_context(g):
 
         if key in terms:
             current = terms[key]["@id"] if isinstance(terms[key], dict) else terms[key]
-            logging.error(f"ERROR: Duplicate context key '{key}' for '{subject}'. Already mapped to '{current}'")
+            logging.error(
+                f"ERROR: Duplicate context key '{key}' for '{subject}'. Already mapped to '{current}'"
+            )
             continue
 
         terms[key] = get_subject_term(subject)


### PR DESCRIPTION
Having a unified graph presents a problem for SHACL validation because instances of objects (e.g. Named Individuals) in the shapes graph are validated against the shapes. This doesn't work because the Named Individuals are not fully defined objects, just references.

The solution to this is to split the shapes graph and the ontology graph into separate files. SHACL validation tools allow a separate ontology file to be specified which is not subject to the shape graph validation.