### PR TITLE
Adds generation of creationInfo for all Individuals

### DIFF
--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -203,9 +203,18 @@ def gen_rdf_vocabularies(model, g):
 
 
 def gen_rdf_individuals(model, g):
+    def ci_ref(s):
+        return URIRef(URI_BASE + "Core/" + s)
+    ci_node = BNode()
+    g.add((ci_node, ci_ref("comment"), Literal("This individual element was defined by the spec.", lang="en")))
+    g.add((ci_node, ci_ref("created"), Literal("2024-11-22T03:00:01Z", datatype=XSD.dateTimeStamp)))
+    g.add((ci_node, ci_ref("createdBy"), URIRef("https://spdx.org/")))
+    g.add((ci_node, ci_ref("specVersion"), Literal("3.0.1")))
+
     for i in model.individuals.values():
         node = URIRef(i.iri)
         g.add((node, RDF.type, OWL.NamedIndividual))
+        g.add((node, ci_ref("creationInfo"), ci_node))
         if i.summary:
             g.add((node, RDFS.comment, Literal(i.summary, lang="en")))
         typ = i.metadata["type"]

--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -205,13 +205,14 @@ def gen_rdf_vocabularies(model, g):
 def gen_rdf_individuals(model, g):
     def ci_ref(s):
         return URIRef(URI_BASE + "Core/" + s)
-    ci_node = BNode()
-    g.add((ci_node, ci_ref("comment"), Literal("This individual element was defined by the spec.", lang="en")))
-    g.add((ci_node, ci_ref("created"), Literal("2024-11-22T03:00:01Z", datatype=XSD.dateTimeStamp)))
-    g.add((ci_node, ci_ref("createdBy"), URIRef("https://spdx.org/")))
-    g.add((ci_node, ci_ref("specVersion"), Literal("3.0.1")))
 
     for i in model.individuals.values():
+        ci_node = URIRef("https://spdx.org/rdf/3.0.1/creationInfo_" + i.name)
+        g.add((ci_node, RDF.type, ci_ref("CreationInfo")))
+        g.add((ci_node, ci_ref("comment"), Literal("This individual element was defined by the spec.", lang="en")))
+        g.add((ci_node, ci_ref("created"), Literal("2024-11-22T03:00:01Z", datatype=XSD.dateTimeStamp)))
+        g.add((ci_node, ci_ref("createdBy"), URIRef("https://spdx.org/")))
+        g.add((ci_node, ci_ref("specVersion"), Literal("3.0.1")))
         node = URIRef(i.iri)
         g.add((node, RDF.type, OWL.NamedIndividual))
         g.add((node, ci_ref("creationInfo"), ci_node))


### PR DESCRIPTION
A minimal approach of adding a valid `creationInfo` for all defined Individuals.

Waiting for @bact and/or @goneall to verify that the generated RDF passes validation.

Signed-off-by: Alexios Zavras (zvr) <zvr+git@zvr.gr>
