### PR TITLE
Fix abstract validation error and SpdxOrganization URI validation errors

### DIFF
--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -98,8 +98,12 @@ def gen_rdf_classes(model, g):
             g.add((node, RDFS.subClassOf, URIRef(p.iri)))
         if c.metadata["Instantiability"] == "Abstract":
             bnode = BNode()
-            g.add((node, SH["not"], bnode))
-            g.add((bnode, SH["class"], node))
+            g.add((node, SH.property, bnode))
+            g.add((bnode, SH.path, RDF.type))
+            notNode = BNode()
+            g.add((bnode, SH["not"], notNode))
+            hasValueNode = BNode()
+            g.add((notNode, SH["hasValue"], node))
             msg = Literal(
                 f"{node} is an abstract class and should not be instantiated directly. Instantiate a subclass instead.",
                 lang="en",

--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -219,7 +219,7 @@ def gen_rdf_individuals(model, g):
         g.add((ci_node, RDF.type, ci_ref("CreationInfo")))
         g.add((ci_node, RDFS.comment, Literal("This individual element was defined by the spec.", lang="en")))
         g.add((ci_node, ci_ref("created"), Literal("2024-11-22T03:00:01Z", datatype=XSD.dateTimeStamp)))
-        g.add((ci_node, ci_ref("createdBy"), URIRef("https://spdx.org/")))
+        g.add((ci_node, ci_ref("createdBy"), ci_ref("SpdxOrganization")))
         g.add((ci_node, ci_ref("specVersion"), Literal("3.0.1")))
         node = URIRef(i.iri)
         g.add((node, RDF.type, OWL.NamedIndividual))


### PR DESCRIPTION
I got the validation for the spdx-spec example to work fully with some changes to the spec parser plus the change to the model in https://github.com/spdx/spdx-3-model/pull/937

I thought I would share the changes to the spec-parser as a pull request - feel free to re-implement.

This pull request fixes 2 issues in 2 commits.

The first commit implements the abstract class validation as suggested by @JPEWdev  - https://github.com/spdx/spec-parser/issues/165#issuecomment-2529816085

This fixes #165 

The second commit changes the URI for createdBys in the individuals from `<https://spdx.org/>` to `ns1:SpdxOrganization`

This fixes #166 

Note that the order of the constraints are not the same as suggested - here is an example of what is output:

```
 sh:property [ sh:message "https://spdx.org/rdf/3.0.1/terms/Core/ElementCollection is an abstract class and should not be instantiated directly. Instantiate a subclass instead."@en ;
            sh:not [ sh:hasValue ns1:ElementCollection ] ;
            sh:path rdf:type ],
```