### PR TITLE
Display error message when cannot parse Header and Content

### DIFF
--- a/spec_parser/mdparsing.py
+++ b/spec_parser/mdparsing.py
@@ -39,10 +39,15 @@ class SpecFile:
         for p in parts[2:]:
             if p.strip():
                 m = re.fullmatch(self.RE_EXTRACT_HEADER_CONTENT, p)
-                header = m.group(1)
-                content = m.group(2).strip()
-                if content:
-                    self.sections[header] = content
+                if m is None:
+                    logging.error(f"File {fpath!s} may contain an empty section.")
+                else:
+                    header = m.group(1)
+                    content = m.group(2).strip()
+                    if content:
+                        self.sections[header] = content
+                    else:
+                        logging.error(f"Content under header '{header}' in File {fpath!s} is empty.")
 
 
 class Section:


### PR DESCRIPTION
To let the user knows more about why there's an error when re.fullmatch(self.RE_EXTRACT_HEADER_CONTENT) does not match.

For example, in a case similar to https://github.com/spdx/spdx-3-model/pull/947#issuecomment-2590551853