### PR TITLE
Section title "class hierarchy"

### DIFF
--- a/spec_parser/templates/mkdocs/class.md.j2
+++ b/spec_parser/templates/mkdocs/class.md.j2
@@ -10,7 +10,7 @@
 | **SubclassOf** | {{type_link(metadata["SubclassOf"])}} |
 {% endif %}
 
-## Superclasses
+## Class hierarchy
 
 {% set full_inheritance_stack = [fqname] + inheritance_stack %}
 {% for super in full_inheritance_stack | reverse %}

--- a/spec_parser/templates/tex/class.tex.j2
+++ b/spec_parser/templates/tex/class.tex.j2
@@ -12,7 +12,7 @@
 \end{tabular}
 %
 {%if inheritance_stack %}
-\spdxpagepart{Superclasses}
+\spdxpagepart{Class hierarchy}
 \begin{itemize}
 \tightlist
 {% for super in inheritance_stack %}


### PR DESCRIPTION
Simply Changes wording of section showing class hierarchy
in both MkDocs and TeX output.
