### PR TITLE
Rework logging

### DIFF
--- a/runparams.py
+++ b/runparams.py
@@ -16,6 +16,8 @@ class RunParams(SimpleNamespace):
     def __init__(self, name):
         self._ts = datetime.now(timezone.utc)
         self.log = logging.getLogger(name)
+        lch = LogCountingHandler()
+        self.log.addHandler(lch)
         opt_force = self.process_args()
         self.check_requirements()
         if logging.ERROR in self.log._cache:
@@ -92,9 +94,9 @@ class RunParams(SimpleNamespace):
         desc_list = ["JSON dump", "MkDocs", "PlantUML", "RDF", "TeX", "Web pages"]
 
         if opts.verbose:
-            self.log.basicConfig(level=logging.INFO)
+            self.log.setLevel(level=logging.INFO)
         if opts.debug:
-            self.log.basicConfig(level=logging.DEBUG)
+            self.log.setLevel(level=logging.DEBUG)
 
         self.input_path = Path(opts.input_dir)
         check_input_path(self.input_path)
@@ -147,4 +149,23 @@ class RunParams(SimpleNamespace):
                 if force and p.exists():
                     shutil.rmtree(p)
                 p.mkdir(parents=True)
+
+
+
+class LogCountingHandler(logging.Handler):
+    def __init__(self):
+        super().__init__()
+        self.count = dict.fromkeys((logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL), 0)
+
+    def emit(self, record):
+        self.count[record.levelno] += 1
+
+    def num_critical(self):
+        return self.count[logging.CRITICAL]
+    
+    def num_errors(self):
+        return self.count[logging.ERROR]
+
+    def num_warnings(self):
+        return self.count[logging.WARNING]
 

--- a/runparams.py
+++ b/runparams.py
@@ -119,7 +119,7 @@ class RunParams(SimpleNamespace):
         if opts.output:
             self.output_path = Path(opts.output)
             if self.output_path.exists() and not opts.force:
-                self.log.error("Output directory '{self.output_path}' already exists (use -f/--force to overwrite).")
+                self.log.error(f"Output directory '{self.output_path}' already exists (use -f/--force to overwrite).")
 
         for desc, g in zip(desc_list, gen_list):
             genflag = "generate_" + g
@@ -152,17 +152,18 @@ class RunParams(SimpleNamespace):
 
 
 
-class LogCountingHandler(logging.Handler):
+class LogCountingHandler(logging.StreamHandler):
     def __init__(self):
         super().__init__()
         self.count = dict.fromkeys((logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL), 0)
 
     def emit(self, record):
         self.count[record.levelno] += 1
+        super().emit(record)
 
     def num_critical(self):
         return self.count[logging.CRITICAL]
-    
+
     def num_errors(self):
         return self.count[logging.ERROR]
 

--- a/spec_parser/jsondump.py
+++ b/spec_parser/jsondump.py
@@ -3,7 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import jsonpickle
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 def gen_jsondump(model, outpath, cfg):
     f = outpath / "model.json"
     f.write_text(jsonpickle.encode(model, indent=2, warn=True))
+

--- a/spec_parser/loaders.py
+++ b/spec_parser/loaders.py
@@ -2,12 +2,16 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+
 from .mdparsing import (
     ContentSection,
     NestedListSection,
     SingleListSection,
     SpecFile,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class NamespaceLoader:

--- a/spec_parser/mkdocs.py
+++ b/spec_parser/mkdocs.py
@@ -2,8 +2,11 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 from jinja2 import Environment, PackageLoader, select_autoescape
 
+
+logger = logging.getLogger(__name__)
 
 def gen_mkdocs(model, outpath, cfg):
     jinja = Environment(

--- a/spec_parser/plantuml.py
+++ b/spec_parser/plantuml.py
@@ -2,6 +2,9 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+
+logger = logging.getLogger(__name__)
 
 def gen_plantuml(model, outpath, cfg):
 

--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -55,7 +55,7 @@ def gen_rdf_ontology(model):
     node = URIRef(URI_BASE)
     g.add((node, RDF.type, OWL.Ontology))
     g.add((node, OWL.versionIRI, node))
-    g.add((node, RDFS.label, Literal("System Package Data Exchange (SPDX) Ontology", lang="en")))
+    g.add((node, RDFS.label, Literal("System Package Data Exchange™ (SPDX®) Ontology", lang="en")))
     g.add(
         (
             node,

--- a/spec_parser/tex.py
+++ b/spec_parser/tex.py
@@ -2,10 +2,13 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import subprocess
 
 from jinja2 import Environment, PackageLoader, select_autoescape
 
+
+logger = logging.getLogger(__name__)
 
 def gen_tex(model, outpath, cfg):
     jinja = Environment(


### PR DESCRIPTION
This reworks the logging infrastructure.

For example,

- logging instance per module.
- keep track of number of messages

Not all messages have been added yet.

Oh, and include trademark symbols on top-level description


