### PR TITLE
Write unlisted namespaces when generate model-files.yml

### DIFF
--- a/spec_parser/mkdocs.py
+++ b/spec_parser/mkdocs.py
@@ -70,10 +70,8 @@ def gen_mkdocs(model, outpath, cfg):
         files[nsn].extend(_gen_filelist(nsn, ns.individuals, "Individuals"))
         files[nsn].extend(_gen_filelist(nsn, ns.datatypes, "Datatypes"))
 
-    filelines = []
-    filelines.append("- model:")
     # hardwired order of namespaces
-    for nsname in [
+    namespace_order = [
         "Core",
         "Software",
         "Security",
@@ -83,9 +81,22 @@ def gen_mkdocs(model, outpath, cfg):
         "Dataset",
         "AI",
         "Build",
+        "Service",
         "Lite",
         "Extension",
-    ]:
+    ]
+
+    # Sort namespaces according to the order in namespace_order, if present.
+    # If a namespace is not in namespace_order, it will be added at the end
+    # of the list, sorted alphabetically.
+    namespaces: List[str] = list(files.keys())
+    ordered_ns = [ns for ns in namespace_order if ns in namespaces]
+    remaining_ns = sorted([ns for ns in namespaces if ns not in namespace_order])
+    namespaces = ordered_ns + remaining_ns
+
+    filelines = []
+    filelines.append("- model:")
+    for nsname in namespaces:
         filelines.extend(files[nsname])
 
     fn = outpath / "model-files.yml"


### PR DESCRIPTION
## Background

- Current code relies on a list ([mkdocs.py line 76-88](https://github.com/spdx/spec-parser/blob/014185824bc0d2080495b66fa1f923935737afaf/spec_parser/mkdocs.py#L75-L88)) to write profile namespaces in a specific order to `model-files.yml`.
- The list includes all the profile namespaces in SPDX 3.0 and works well with 3.0.
- It is however does not write new namespaces in SPDX 3.1 ("Service", for example) to `model-files.yml` and this makes the publishing workflow failed https://github.com/spdx/spdx-spec/issues/1231

## What this PR does?

- Rely on the existing logic, sort namespaces according to the hardwired order (`namespace_order`), if present.
  - If a namespace is in the hardwired order but not actually present in `files`, just skip (to keep backward compatibility)
- If a namespace is not in the hardwired order, it will be added at the end of the list.
  - This will make it support new namespaces that is currently unknown (to maintain forward compatibility)

The code is tested with both SPDX 3.0 (without "Service" profile) and SPDX 3.1 (with "Service" profile) models and it is working well with both versions.

To resolve #189 and https://github.com/spdx/spdx-spec/issues/1231

<img width="856" height="687" alt="Service profile in SPDX 3.1" src="https://github.com/user-attachments/assets/930ec6d1-92fc-4ea2-9fc4-fac228e4874a" />
