### PR TITLE
Handle new profiles

### DIFF
--- a/spec_parser/mkdocs.py
+++ b/spec_parser/mkdocs.py
@@ -94,7 +94,7 @@ def gen_mkdocs(model, outpath, cfg):
             namespaces.remove(nsname)
 
     if namespaces:
-        logger.warning("The following namespaces were not processed: %s", ", ".join(namespaces))
+        logger.warning("The following namespaces were not processed for MkDocs generation: %s", ", ".join(namespaces))
 
     fn = outpath / "model-files.yml"
     fn.write_text("\n".join(filelines))

--- a/spec_parser/tex.py
+++ b/spec_parser/tex.py
@@ -92,7 +92,7 @@ def gen_tex(model, outpath, cfg):
             namespaces.remove(nsname)
 
     if namespaces:
-        logger.warning("The following namespaces were not processed: %s", ", ".join(namespaces))
+        logger.warning("The following namespaces were not processed for TeX generation: %s", ", ".join(namespaces))
 
     fn = p / "model-files.tex"
     fn.write_text("\n".join(filelines))


### PR DESCRIPTION
This PR adds the new Hardware and Service profiles/namespaces to the list of profiles to be handled.

Also adds code to ignore non-existing ones (so that it can run on previous releases without new profiles) and, conversely, also raise a warning if more profiles are found that are not in the "known" list.

The sequence of profiles should be hardwired, so that new additions never change the order of existing ones, since some output formats add automatic numbering.

Closes #189


