### PR TITLE
Fix class hierarchy indentation in one-file output

### DIFF
--- a/spec_parser/templates/word/class.md.j2
+++ b/spec_parser/templates/word/class.md.j2
@@ -14,12 +14,9 @@
 
 {% set full_inheritance_stack = [fqname] + inheritance_stack %}
 {% for super in full_inheritance_stack | reverse %}
-{{ '&nbsp;' * ((loop.index-1) * 6) }}
-  {% if loop.last %}
-{{super}}
-  {% else %}
-{{super}}<br />
-  {% endif %}
+{{ '&nbsp;' * ((loop.index-1) * 6) }}{% if loop.last %}{{super}}
+{% else %}{{super}}   
+{% endif %}
 {% endfor %}
 
 {% endblock %}


### PR DESCRIPTION
This updates the word/class template to not use `<br />` for line breaks, since HTML is not processed in Markdown formatting.