### PR TITLE
Add "FunctionalSafety" to namespace order list

### DIFF
--- a/spec_parser/mkdocs.py
+++ b/spec_parser/mkdocs.py
@@ -90,6 +90,7 @@ def gen_mkdocs(model, outpath, cfg):
         "Service",
         "SupplyChain",
         "Operations",
+        "FunctionalSafety",
     ]:
         if nsname in namespaces:
             filelines.extend(files[nsname])

--- a/spec_parser/singlefile.py
+++ b/spec_parser/singlefile.py
@@ -82,6 +82,7 @@ def gen_singlefile(model, outpath, cfg):
         "Service",
         "SupplyChain",
         "Operations",
+        "FunctionalSafety",
     ]:
         if nsname in namespaces:
             f = p / nsname / f"{nsname}.md"

--- a/spec_parser/tex.py
+++ b/spec_parser/tex.py
@@ -88,6 +88,7 @@ def gen_tex(model, outpath, cfg):
         "Service",
         "SupplyChain",
         "Operations",
+        "FunctionalSafety",
     ]:
         if nsname in namespaces:
             filelines.extend(files[nsname])


### PR DESCRIPTION
A new namespace/profile "FunctionalSafety" is added by https://github.com/spdx/spdx-3-model/pull/1178 and https://github.com/spdx/spdx-3-model/pull/1197.

Add the namespace to namespace lists in spec-parser, so content under the namespace are being displayed on spec website, etc.