### PR TITLE
Read base URI from actual model (Core profile) + add owl:versionInfo

### DIFF
--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 def gen_rdf(model, outpath, cfg):
     p = outpath
 
-    base_uri = "https://spdx.org/rdf/3.1/terms/"
+    base_uri = "https://spdx.org/rdf/3/terms/"
     # Determine actual base URI from Core namespace:
     # https://spdx.org/rdf/<version>/terms/Core/
     # -> https://spdx.org/rdf/<version>/terms/
@@ -250,7 +250,7 @@ def gen_rdf_individuals(model, g, base_uri: str):
         return URIRef(base_uri + "Core/" + s)
 
     for i in model.individuals.values():
-        ci_node = URIRef("https://spdx.org/rdf/3.1/creationInfo_" + i.name)
+        ci_node = URIRef("https://spdx.org/rdf/3/creationInfo_" + i.name)
         g.add((ci_node, RDF.type, ci_ref("CreationInfo")))
         g.add((ci_node, RDFS.comment, Literal("This individual element was defined by the spec.", lang="en")))
         g.add((ci_node, ci_ref("created"), Literal("2026-01-23T03:01:00Z", datatype=XSD.dateTimeStamp)))

--- a/spec_parser/rdf.py
+++ b/spec_parser/rdf.py
@@ -60,7 +60,22 @@ def gen_rdf_ontology(model, base_uri: str):
 
     node = URIRef(base_uri)
     g.add((node, RDF.type, OWL.Ontology))
-    g.add((node, OWL.versionIRI, node))
+
+    # owl:versionInfo / owl:versionIRI from namespace metadata.
+    # Ontology IRI is stable across minor releases (major ver. only in path).
+    # versionIRI identifies the specific release by replacing the major version
+    # segment with the full version: https://spdx.org/rdf/3/terms/ (ontology)
+    # -> https://spdx.org/rdf/3.1/terms/ (versionIRI for 3.1 release).
+    # W3C OWL 2 Section 3.1:
+    # https://www.w3.org/TR/owl2-syntax/#Ontology_IRI_and_Version_IRI
+    for ns in model.namespaces:
+        v = ns.metadata.get("version") or ns.metadata.get("Version")
+        if v:
+            g.add((node, OWL.versionInfo, Literal(v)))
+            major = v.split(".")[0]
+            versioned_iri = URIRef(base_uri.replace(f"/{major}/", f"/{v}/", 1))
+            g.add((node, OWL.versionIRI, versioned_iri))
+            break
     g.add((node, RDFS.label, Literal("System Package Data Exchange™ (SPDX®) Ontology", lang="en")))
     g.add(
         (


### PR DESCRIPTION
Use the Core namespace in the model as source, instead of hard-coded in parser.

To resolve #203

Note that the base IRI is updated to the MAJOR-only one: `https://spdx.org/rdf/3/terms/`

`owl:versionIRI` can be generated, if a version metadata is provided, like this:

```markdown
## Metadata

- id: https://spdx.org/rdf/3/terms/Core
- name: Core
- version: 3.1
```

From this example,
-  Base IRI (in `owl:Ontology`) will be `https://spdx.org/rdf/3/terms/`
- `owl:versionInfo` will be `3.1`
- `owl:versionIRI` will be `https://spdx.org/rdf/3.1/terms/`

If version is absent from namespace metadata, `owl:versionInfo` and `owl:versionIRI` are omitted silently. The ontology remains valid OWL.