### PR TITLE
Show class hierarchy info

### DIFF
--- a/spec_parser/mkdocs.py
+++ b/spec_parser/mkdocs.py
@@ -99,6 +99,11 @@ def gen_mkdocs(model, outpath, cfg):
     if namespaces:
         logger.warning("The following namespaces were not processed for MkDocs generation: %s", ", ".join(namespaces))
 
+    fn = outpath / "class-hierarchy.md"
+    template = jinja.get_template("hierarchy.md.j2")
+    page = template.render(vars(model))
+    fn.write_text(page)
+
     fn = outpath / "model-files.yml"
     fn.write_text("\n".join(filelines))
 

--- a/spec_parser/model.py
+++ b/spec_parser/model.py
@@ -102,6 +102,8 @@ class Model:
             parent = c.fqsupercname
             if parent:
                 inheritances.append((c.fqname, parent))
+                self.classes[parent].direct_subclasses.append(c.fqname)
+        self.inheritances = inheritances
 
         def _tsort_recursive(inh, cn, visited, stack):
             visited[cn] = True
@@ -119,7 +121,6 @@ class Model:
                 _tsort_recursive(inheritances, c.fqname, visited, stack)
         for cn in stack:
             c = self.classes[cn]
-            c.inheritance_stack = []
             pcn = c.fqsupercname
             while pcn:
                 c.inheritance_stack.append(pcn)
@@ -278,6 +279,10 @@ class Class:
             if not parent.startswith("/"):
                 parent = f"/{ns.name}/{parent}"
         self.fqsupercname = parent
+
+        self.inheritance_stack = []
+        self.direct_subclasses = []
+        self.all_properties = dict()
 
 
 class Property:

--- a/spec_parser/model.py
+++ b/spec_parser/model.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+from collections import defaultdict
 from copy import deepcopy
 
 from .mdparsing import ContentSection, NestedListSection, SingleListSection, SpecFile
@@ -103,7 +104,17 @@ class Model:
             if parent:
                 inheritances.append((c.fqname, parent))
                 self.classes[parent].direct_subclasses.append(c.fqname)
-        self.inheritances = inheritances
+
+        tree = defaultdict(list)
+        children = set()
+        nodes = set()
+        for child, parent in inheritances:
+            tree[parent].append(child)
+            children.add(child)
+            nodes.add(parent)
+            nodes.add(child)
+        self.class_hierarchy = dict(tree)
+        self.toplevel_classes = list(nodes - children)
 
         def _tsort_recursive(inh, cn, visited, stack):
             visited[cn] = True

--- a/spec_parser/templates/mkdocs/class.md.j2
+++ b/spec_parser/templates/mkdocs/class.md.j2
@@ -22,6 +22,14 @@
   {% endif %}
 {% endfor %}
 
+{% if direct_subclasses %}
+### Direct subclasses
+
+{% for subclass in direct_subclasses | sort %}
+- {{type_link(subclass)}}
+{% endfor %}
+{% endif %}
+
 {% endblock %}
 
 {% block extra %}

--- a/spec_parser/templates/mkdocs/hierarchy.md.j2
+++ b/spec_parser/templates/mkdocs/hierarchy.md.j2
@@ -1,0 +1,55 @@
+# Class Hierarchy (Informational)
+
+{% macro render_tree(node, tree) %}
+    {% if node in tree %}
+        <li>
+            <details open>
+                <summary>{{ node }}</summary>
+                <ul>
+                    {% for child in tree[node] | sort %}
+                        {{ render_tree(child, tree) }}
+                    {% endfor %}
+                </ul>
+            </details>
+        </li>
+    {% else %}
+        <li class="classhier-leaf">{{ node }}</li>
+    {% endif %}
+{% endmacro %}
+
+<ul class="classhier-view">
+{% for root in toplevel_classes | sort%}
+    {{ render_tree(root, class_hierarchy) }}
+{% endfor %}
+</ul>
+
+
+<style>
+/* CSS specific to this tree to avoid conflicts with other MkDocs styles */
+.classhier-view ul { list-style-type: none; padding-left: 20px; margin: 0; }
+.classhier-view li { margin: 5px 0; }
+
+/* Style the clickable text */
+.classhier-view summary { 
+    cursor: pointer; 
+    font-weight: bold; 
+    padding: 5px;
+    background-color: var(--md-code-bg-color, #f0f0f0); /* Uses MkDocs theme var or fallback */
+    border-radius: 4px;
+    display: inline-block;
+    min-width: 150px;
+}
+.classhier-view summary:hover { background-color: var(--md-accent-fg-color--transparent, #e0e0e0); }
+
+/* Style leaf nodes */
+.classhier-leaf { 
+    padding: 5px; 
+    padding-left: 25px; 
+    color: var(--md-default-fg-color--light, #555);
+}
+
+/* Custom +/- icons */
+.classhier-view summary::marker, .classhier-view summary::-webkit-details-marker { display: none; content: ""; }
+.classhier-view details > summary::before { content: "+ "; display: inline-block; width: 15px; font-family: monospace; }
+.classhier-view details[open] > summary::before { content: "- "; }
+</style>


### PR DESCRIPTION
This adds the generation of a spec Annex, that includes the complete class hierarchy tree.

It also adds showing the direct sublasses in every MkDocs class page.

TODO: in the spec repo, actually include the new Annex in the MkDocs configuration.

