### PR TITLE
Use sentence casing for "Class hierarchy"

### DIFF
--- a/spec_parser/templates/mkdocs/hierarchy.md.j2
+++ b/spec_parser/templates/mkdocs/hierarchy.md.j2
@@ -1,4 +1,4 @@
-# Class Hierarchy (Informational)
+# Class hierarchy (Informational)
 
 {% macro render_tree(node, tree) %}
     {% if node in tree %}


### PR DESCRIPTION
Make it consistent with other Annexes' heading