### PR TITLE
Always show the Properties section in a class

### DIFF
--- a/spec_parser/templates/mkdocs/class.md.j2
+++ b/spec_parser/templates/mkdocs/class.md.j2
@@ -34,15 +34,16 @@
 
 {% block extra %}
 
-{% if properties %}
 ## Properties
 
+{% if properties %}
 | Property | Type | minCount | maxCount |
 |---|---|:---:|:---:|
     {% for name, kv in properties | dictsort %}
 | {{property_link(name)}} | {{type_link(kv["type"])}} | {{kv["minCount"]}} | {{kv["maxCount"]}} |
     {% endfor %}
-
+{% else %}
+No properties defined in this class.
 {% endif %}
 
 {% if ext_prop_restrs %}

--- a/spec_parser/templates/singlefile/class.md.j2
+++ b/spec_parser/templates/singlefile/class.md.j2
@@ -23,15 +23,16 @@
 
 {% block extra %}
 
-{% if properties %}
 #### Properties
 
+{% if properties %}
 | Property | Type | minCount | maxCount |
 |---|---|:---:|:---:|
     {% for name, kv in properties | dictsort %}
 | {{name}} | {{kv["type"]}} | {{kv["minCount"]}} | {{kv["maxCount"]}} |
     {% endfor %}
-
+{% else %}
+No properties defined in this class.
 {% endif %}
 
 {% if ext_prop_restrs %}

--- a/spec_parser/templates/tex/class.tex.j2
+++ b/spec_parser/templates/tex/class.tex.j2
@@ -23,8 +23,8 @@
 {% endblock %}
 
 {% block extra %}
-{% if properties %}
 \spdxpagepart{Properties}
+{% if properties %}
 \begin{tabular}{ l l c c } 
 \toprule
  Property & Type & minCount & maxCount \\
@@ -35,6 +35,8 @@
 \bottomrule
 \end{tabular} 
 \par
+{% else %}
+No properties defined in this class.
 {% endif %}
 
 {% if ext_prop_restrs %}


### PR DESCRIPTION
Even when a class does not define any properties, generate the Properties section for consistency and uniformity.


